### PR TITLE
Made user_id on charges migration reflect Laravel's change of user id column

### DIFF
--- a/src/ShopifyApp/resources/database/migrations/2020_01_29_231006_create_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2020_01_29_231006_create_charges_table.php
@@ -77,7 +77,7 @@ class CreateChargesTable extends Migration
             $table->softDeletes();
 
             // Linking
-            $table->integer('user_id')->unsigned();
+            $table->bigInteger('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('plan_id')->references('id')->on('plans');
         });


### PR DESCRIPTION
On August 18, 2018, Laravel merged a change into all new user migrations. Laravel no longer sets the `id` column on the `users` table to `integer`, but instead uses `bigInteger`. The charges migration contained a `user_id` column that was not compatible with newer Laravel apps for this reason.

While you can publish your own migrations and make adjustments, if you're wanting to support newer Laravel versions going forward it should be changed to `bigInteger`. This pull request makes that change.