### PR TITLE
Added dropForeign and removed call to drop unused columns

### DIFF
--- a/src/ShopifyApp/resources/database/migrations/2020_01_29_230905_create_shops_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2020_01_29_230905_create_shops_table.php
@@ -33,9 +33,8 @@ class CreateShopsTable extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign('users_plan_id_foreign');
             $table->dropColumn([
-                'shopify_domain',
-                'shopify_token',
                 'shopify_grandfathered',
                 'shopify_namespace',
                 'shopify_freemium',


### PR DESCRIPTION
This PR fixes 1 issue and cleans up some unused data.

**Issue**
When working on the database in dev it's common to run `php artisan migrate:refresh --seed`. When attempting to refresh a database that already has tables, columns and data it throws the following error:

	   Illuminate\Database\QueryException 

	  SQLSTATE[HY000]: General error: 1828 Cannot drop column 'plan_id': needed in a foreign key constraint 'users_plan_id_foreign' (SQL: alter table `users` drop `shopify_grandfathered`, drop `shopify_namespace`, drop `shopify_freemium`, drop `plan_id`)

	  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:669
		665|         // If an exception occurs when attempting to run a query, we'll format the error
		666|         // message to include the bindings with SQL, which will make this exception a
		667|         // lot more helpful to the developer instead of just the database's errors.
		668|         catch (Exception $e) {
	  > 669|             throw new QueryException(
		670|                 $query, $this->prepareBindings($bindings), $e
		671|             );
		672|         }
		673| 

This is because the `users` table goes first and it's attempting to drop the `plan_id` column which references the `id` column in the `plans` table. Laravel can't drop `plan_id` and so the rollback fails. To reproduce this error:

1. Create a new Laravel app
2. Install the package
3. Seed one plan
4. run `php artisan:migrate refresh --seed` to set up the database
5. run `php artisan:migrate refresh --seed` to tear down the database and rebuild. You will encounter this error at this point.

This PR fixes this by adding `$table->dropForeign('users_plan_id_foreign');` in the `down()` method of the create_shops migration.

**Clean up issue**

It appears that `shopify_domain` and `shopify_token` are no longer used in the database. They still exist in the `down()` method of the create_shops migration file. This PR simply removes them.