### PR TITLE
Changed "cappedTerms" to "terms" 

### DIFF
--- a/src/ShopifyApp/Objects/Transfers/PlanDetails.php
+++ b/src/ShopifyApp/Objects/Transfers/PlanDetails.php
@@ -46,7 +46,7 @@ final class PlanDetails extends AbstractTransfer
      *
      * @var string|null
      */
-    public $cappedTerms;
+    public $terms;
 
     /**
      * Plan return URL.
@@ -66,7 +66,7 @@ final class PlanDetails extends AbstractTransfer
             'test'          => $this->test,
             'trial_days'    => $this->trialDays,
             'return_url'    => $this->returnUrl,
-            'capped_terms'  => $this->cappedTerms,
+            '$terms'        => $this->terms,
             'capped_amount' => $this->cappedAmount
         ];
     }

--- a/src/ShopifyApp/Objects/Transfers/PlanDetails.php
+++ b/src/ShopifyApp/Objects/Transfers/PlanDetails.php
@@ -46,7 +46,13 @@ final class PlanDetails extends AbstractTransfer
      *
      * @var string|null
      */
-    public $terms;
+    public $terms;    
+    /**
+     * cappedTerms
+     *
+     * @var mixed
+     */
+    public $cappedTerms;
 
     /**
      * Plan return URL.
@@ -66,7 +72,8 @@ final class PlanDetails extends AbstractTransfer
             'test'          => $this->test,
             'trial_days'    => $this->trialDays,
             'return_url'    => $this->returnUrl,
-            '$terms'        => $this->terms,
+            'cappedTerms'   => $this->cappedTerms,
+            'terms'         => $this->terms,
             'capped_amount' => $this->cappedAmount
         ];
     }

--- a/src/ShopifyApp/Services/ChargeHelper.php
+++ b/src/ShopifyApp/Services/ChargeHelper.php
@@ -264,8 +264,8 @@ class ChargeHelper
         $transfer->price = $plan->price;
         $transfer->test = $plan->isTest();
         $transfer->trialDays = $this->determineTrialDaysRemaining($plan, $shop);
-        $transfer->cappedAmount = $isCapped ? $this->capped_amount : null;
-        $transfer->cappedTerms = $isCapped ? $this->terms : null;
+        $transfer->cappedAmount = $isCapped ? $plan->capped_amount : null;
+        $transfer->terms = $isCapped ? $plan->terms : null;
         $transfer->returnUrl = URL::secure(
             $this->getConfig('billing_redirect'),
             ['plan_id' => $plan->getId()->toNative()]


### PR DESCRIPTION
Changed "cappedTerms" to "terms" for api request when selecting a plan with a non-negative value of 'capped_amount'.