### PR TITLE
Only process needed request values

### DIFF
--- a/src/ShopifyApp/Http/Middleware/AuthShopify.php
+++ b/src/ShopifyApp/Http/Middleware/AuthShopify.php
@@ -236,9 +236,12 @@ class AuthShopify
             // GET/POST
             DataSource::INPUT()->toNative() => function () use ($request): array {
                 // Verify
+                $shopify_values = array('shop', 'hmac', 'timestamp', 'timestamp');
                 $verify = [];
                 foreach ($request->all() as $key => $value) {
-                    $verify[$key] = is_array($value) ? '["'.implode('", "', $value).'"]' : $value;
+                    if(in_array($key, $shopify_values)) {
+                        $verify[$key] = is_array($value) ? '["'.implode('", "', $value).'"]' : $value;
+                    }
                 }
 
                 return $verify;

--- a/src/ShopifyApp/Http/Middleware/AuthShopify.php
+++ b/src/ShopifyApp/Http/Middleware/AuthShopify.php
@@ -236,12 +236,9 @@ class AuthShopify
             // GET/POST
             DataSource::INPUT()->toNative() => function () use ($request): array {
                 // Verify
-                $shopify_values = array('shop', 'hmac', 'timestamp', 'timestamp');
                 $verify = [];
-                foreach ($request->all() as $key => $value) {
-                    if (in_array($key, $shopify_values)) {
-                        $verify[$key] = is_array($value) ? '["'.implode('", "', $value).'"]' : $value;
-                    }
+                foreach ($request->query() as $key => $value) {
+                    $verify[$key] = is_array($value) ? '["'.implode('", "', $value).'"]' : $value;
                 }
 
                 return $verify;

--- a/src/ShopifyApp/Http/Middleware/AuthShopify.php
+++ b/src/ShopifyApp/Http/Middleware/AuthShopify.php
@@ -239,7 +239,7 @@ class AuthShopify
                 $shopify_values = array('shop', 'hmac', 'timestamp', 'timestamp');
                 $verify = [];
                 foreach ($request->all() as $key => $value) {
-                    if(in_array($key, $shopify_values)) {
+                    if (in_array($key, $shopify_values)) {
                         $verify[$key] = is_array($value) ? '["'.implode('", "', $value).'"]' : $value;
                     }
                 }


### PR DESCRIPTION
I was getting a PHP compile error on `implode` because I was sending other data through the an API route. Meaning I had payload data in my request and this function was not processing it correctly.

**Note:** I'm not entirely sure that `$shopify_values` actually contains all the values needed. 