### PR TITLE
Fix counting remaining trial days when recharge cancelled billing

### DIFF
--- a/src/ShopifyApp/Storage/Queries/Charge.php
+++ b/src/ShopifyApp/Storage/Queries/Charge.php
@@ -31,6 +31,7 @@ class Charge implements IChargeQuery
     {
         return ChargeModel::with($with)
             ->where('charge_id', $chargeRef->toNative())
+            ->withTrashed()
             ->get()
             ->first();
     }


### PR DESCRIPTION
Charge model using SoftDelete. When shop reinstalling app and recharge billing with trial plan, we should find latest charge(include trashed) data for counting remaining of trial days.