### PR TITLE
correct version check for Laravel 5.8 introduction of bigIncrements

### DIFF
--- a/src/ShopifyApp/resources/database/migrations/2020_01_29_231006_create_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2020_01_29_231006_create_charges_table.php
@@ -77,7 +77,7 @@ class CreateChargesTable extends Migration
             // Allows for soft deleting
             $table->softDeletes();
 
-            if ($this->getLaravelVersion() < 5.9) {
+            if ($this->getLaravelVersion() < 5.8) {
                 $table->integer('user_id')->unsigned();
             } else {
                 $table->bigInteger('user_id')->unsigned();


### PR DESCRIPTION
Laravel changed the user_id column to be a big increments in v5.8 and this bug was raised and fixed to cater for it:
https://github.com/osiset/laravel-shopify/issues/419

However, the version check excludes v5.8 when it should be included. This PR fixes the conditional version check.