### PR TITLE
Parse query strings the same as Shopify to support array parameters

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,6 @@
 # [...document.getElementsByClassName('contrib-person')].map(n => n.getElementsByClassName('avatar')[0].alt).join('\n');
 osiset
+joelvh
 darrynten
 amosmos
 jedimdan

--- a/src/ShopifyApp/Http/Middleware/AuthProxy.php
+++ b/src/ShopifyApp/Http/Middleware/AuthProxy.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
 use function Osiset\ShopifyApp\createHmac;
+use function Osiset\ShopifyApp\parseQueryString;
 use Osiset\ShopifyApp\Services\ShopSession;
 use Osiset\ShopifyApp\Traits\ConfigAccessible;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
@@ -49,7 +50,7 @@ class AuthProxy
     public function handle(Request $request, Closure $next)
     {
         // Grab the query parameters we need
-        $query = $request->query->all();
+        $query = $this->getQueryStringParameters($request);
         $signature = isset($query['signature']) ? $query['signature'] : null;
         $shop = NullableShopDomain::fromNative($query['shop'] ?? null);
 
@@ -70,5 +71,17 @@ class AuthProxy
 
         // All good, process proxy request
         return $next($request);
+    }
+
+    /**
+     * Parse query strings the same way Shopify does.
+     *
+     * @param Request  $request The request object.
+     *
+     * @return array
+     */
+    protected function getQueryStringParameters(Request $request): array
+    {
+        return parseQueryString($request->server->get('QUERY_STRING'));
     }
 }

--- a/src/ShopifyApp/helpers.php
+++ b/src/ShopifyApp/helpers.php
@@ -24,7 +24,7 @@ function createHmac(array $opts, string $secret): string
         ksort($data);
         $queryCompiled = [];
         foreach ($data as $key => $value) {
-            $queryCompiled[] = "{$key}=".(is_array($value) ? implode(',', $value) : $value);
+            $queryCompiled[] = "{$key}=" . (is_array($value) ? implode(',', $value) : $value);
         }
         $data = implode(
             ($buildQueryWithJoin ? '&' : ''),
@@ -37,4 +37,51 @@ function createHmac(array $opts, string $secret): string
 
     // Return based on options
     return $encode ? base64_encode($hmac) : $hmac;
+}
+
+
+/**
+ * Parse query strings the same way as Rack::Until in Ruby. (This is a port from Rack 2.3.0.)
+ *
+ * From Shopify's docs, they use Rack::Util.parse_query, which does *not* parse array parameters properly.
+ * Array parameters such as `name[]=value1&name[]=value2` becomes `['name[]' => ['value1', 'value2']] in Shopify.
+ * See: https://github.com/rack/rack/blob/f9ad97fd69a6b3616d0a99e6bedcfb9de2f81f6c/lib/rack/query_parser.rb#L36
+ *
+ * @param string $qs The query string.
+ * @param string $d  The delimiter.
+ *
+ * @return mixed
+ */
+function parseQueryString(string $qs, string $d = null): array
+{
+    $COMMON_SEP = [';' => '/[;]\s*/', ';,' => '/[;,]\s*/', '&' => '/[&]\s*/'];
+    $DEFAULT_SEP = '/[&;]\s*/';
+
+    $params = [];
+    $split = preg_split($d ? ($COMMON_SEP[$d] || '/[' . $d . ']\s*/') : $DEFAULT_SEP, $qs ?? '');
+
+    foreach ($split as $p) {
+        if (!$p) {
+            continue;
+        }
+
+        list($k, $v) = strpos($p, '=') !== false ? explode('=', $p, 2) : [$p, null];
+
+        $k = urldecode($k);
+        $v = $v != null ? urldecode($v) : $v;
+
+        if (isset($params[$k])) {
+            $cur = $params[$k];
+
+            if (is_array($cur)) {
+                $params[$k][] = $v;
+            } else {
+                $params[$k] = [$cur, $v];
+            }
+        } else {
+            $params[$k] = $v;
+        }
+    }
+
+    return $params;
 }

--- a/tests/Http/Middleware/AuthProxyTest.php
+++ b/tests/Http/Middleware/AuthProxyTest.php
@@ -2,13 +2,15 @@
 
 namespace Osiset\ShopifyApp\Test\Http\Middleware;
 
+use Osiset\ShopifyApp\Test\Http\Middleware\LegacyAuthProxy as LegacyAuthProxyMiddleware;
 use Osiset\ShopifyApp\Test\TestCase;
 use Illuminate\Support\Facades\Request;
 use Osiset\ShopifyApp\Http\Middleware\AuthProxy as AuthProxyMiddleware;
 
 class AuthProxyTest extends TestCase
 {
-    protected $queryParams;
+    protected $queryString, $queryParams;
+    protected $queryStringArrayFormat, $queryParamsArrayFormat;
 
     public function setUp(): void
     {
@@ -16,6 +18,9 @@ class AuthProxyTest extends TestCase
 
         // Make the shop
         factory($this->model)->create(['name' => 'shop-name.myshopify.com']);
+
+        // From Shopify's docs
+        $this->queryString = 'extra=1&extra=2&shop=shop-name.myshopify.com&path_prefix=%2Fapps%2Fawesome_reviews&timestamp=1317327555&signature=a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3';
 
         // From Shopify's docs
         $this->queryParams = [
@@ -26,6 +31,17 @@ class AuthProxyTest extends TestCase
             'signature'   => 'a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3',
         ];
 
+        // Array parameter format
+        $this->queryStringArrayFormat = 'extra[]=1&extra[]=2&shop=shop-name.myshopify.com&path_prefix=%2Fapps%2Fawesome_reviews&timestamp=1317327555&signature=6f4b878d5340128aab03a234676dba228432b0b8b72863828ec143e4c5772124';
+
+        $this->queryParamsArrayFormat = [
+            'extra'       => ['1', '2'],
+            'shop'        => 'shop-name.myshopify.com',
+            'path_prefix' => '/apps/awesome_reviews',
+            'timestamp'   => '1317327555',
+            'signature'   => '6f4b878d5340128aab03a234676dba228432b0b8b72863828ec143e4c5772124',
+        ];
+
         // Set the app secret to match Shopify's docs
         $this->app['config']->set('shopify-app.api_secret', 'hush');
     }
@@ -33,6 +49,7 @@ class AuthProxyTest extends TestCase
     public function testRuns(): void
     {
         Request::merge($this->queryParams);
+        Request::instance()->server->set('QUERY_STRING', $this->queryString);
 
         // Run the middleware
         $result = $this->runAuthProxy();
@@ -41,12 +58,13 @@ class AuthProxyTest extends TestCase
         $this->assertTrue($result[1]);
     }
 
-    public function testDenysForMissingShop(): void
+    public function testDeniesForMissingShop(): void
     {
         // Remove shop from params
         $query = $this->queryParams;
         unset($query['shop']);
         Request::merge($query);
+        Request::instance()->server->set('QUERY_STRING', 'extra=1&extra=2&path_prefix=%2Fapps%2Fawesome_reviews&timestamp=1317327555&signature=a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3');
 
         // Run the middleware
         $result = $this->runAuthProxy();
@@ -62,6 +80,7 @@ class AuthProxyTest extends TestCase
         $query = $this->queryParams;
         $query['oops'] = 'i-did-it-again';
         Request::merge($query);
+        Request::instance()->server->set('QUERY_STRING', $this->queryString . '&oops=i-did-it-again');
 
         // Run the middleware
         $result = $this->runAuthProxy();
@@ -71,10 +90,32 @@ class AuthProxyTest extends TestCase
         $this->assertEquals(401, $result[0]->status());
     }
 
-    private function runAuthProxy(Closure $cb = null): array
+    public function testQueryStringArrayFormatParsedProperly(): void
+    {
+        Request::merge($this->queryParamsArrayFormat);
+        Request::instance()->server->set('QUERY_STRING', $this->queryStringArrayFormat);
+
+        // Run the middleware using Rack-based query string parsing
+        $result = $this->runAuthProxy();
+
+        $this->assertTrue($result[1]);
+    }
+
+    public function testQueryStringArrayFormatParsedIncorrectly(): void
+    {
+        Request::merge($this->queryParamsArrayFormat);
+        Request::instance()->server->set('QUERY_STRING', $this->queryStringArrayFormat);
+
+        // Run the middleware using Laravel-based query string parsing
+        $result = $this->runAuthProxy(LegacyAuthProxyMiddleware::class);
+
+        $this->assertFalse($result[1]);
+    }
+
+    private function runAuthProxy($class = AuthProxyMiddleware::class): array
     {
         $called = false;
-        $response = ($this->app->make(AuthProxyMiddleware::class))->handle(Request::instance(), function ($request) use (&$called, $cb) {
+        $response = ($this->app->make($class))->handle(Request::instance(), function ($request) use (&$called) {
             $called = true;
         });
 

--- a/tests/Http/Middleware/LegacyAuthProxy.php
+++ b/tests/Http/Middleware/LegacyAuthProxy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Osiset\ShopifyApp\Http\Middleware\AuthProxy;
+
+/**
+ * Uses Laravel query string parsing to show invalid signatures for array parameters.
+ */
+class LegacyAuthProxy extends AuthProxy
+{
+    /**
+     * Use Laravel query string parsing to show invalid signatures.
+     *
+     * @param Request  $request The request object.
+     *
+     * @return array
+     */
+    protected function getQueryStringParameters(Request $request): array
+    {
+        return $request->query->all();
+    }
+}


### PR DESCRIPTION
Shopify does not parse the query string of a request with array parameters the same way as Laravel. While Laravel and most web frameworks parse `name[]=value` to `['name' => ['value']]`, Shopify parses it to `['name[]' => 'value']`. (When there are multiple parameters with the same name, Shopify will put the values in an array.)

The reason for this is shown in the [Shopify docs](https://shopify.dev/tutorials/display-data-on-an-online-store-with-an-application-proxy-app-extension): they use [`Rack::Util.parse_query`](https://github.com/rack/rack/blob/f9ad97fd69a6b3616d0a99e6bedcfb9de2f81f6c/lib/rack/query_parser.rb#L36).

```ruby
require 'rack/utils'

# Use request.query_string in rails
query_string = "extra=1&extra=2&shop=shop-name.myshopify.com&path_prefix=%2Fapps%2Fawesome_reviews&timestamp=1317327555&signature=a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3"

query_hash = Rack::Utils.parse_query(query_string)
# => {
#   "extra" => ["1", "2"],
#   "shop" => "shop-name.myshopify.com",
#   "path_prefix" => "/apps/awesome_reviews",
#   "timestamp" => "1317327555",
#   "signature" => "a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3",
# }
```

We've been running into issues with array parameters, and decided to port the Ruby code to PHP to ensure the exact same query string parsing as Shopify uses to create the HMAC signature.