### PR TITLE
Recurring annual subscription on Shopify API 2020-07

### DIFF
--- a/src/ShopifyApp/Actions/ActivatePlan.php
+++ b/src/ShopifyApp/Actions/ActivatePlan.php
@@ -74,7 +74,7 @@ class ActivatePlan
      * @param IChargeCommand $chargeCommand           The commands for charges.
      * @param IShopCommand   $shopCommand             The commands for shops.
      *
-     * @return self
+     * @return void
      */
     public function __construct(
         callable $cancelCurrentPlanAction,

--- a/src/ShopifyApp/Actions/GetPlanUrl.php
+++ b/src/ShopifyApp/Actions/GetPlanUrl.php
@@ -72,7 +72,7 @@ class GetPlanUrl
         // Confirmation URL
         $confirmation_url = null;
 
-        switch($plan->getInterval()->toNative()) {
+        switch ($plan->getInterval()->toNative()) {
             case ChargeInterval::ANNUAL()->toNative():
                 $api = $shop->apiHelper()->createChargeGraphQL(
                     $this->chargeHelper->details($plan, $shop)

--- a/src/ShopifyApp/Actions/GetPlanUrl.php
+++ b/src/ShopifyApp/Actions/GetPlanUrl.php
@@ -2,6 +2,7 @@
 
 namespace Osiset\ShopifyApp\Actions;
 
+use Osiset\ShopifyApp\Objects\Enums\ChargeInterval;
 use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Objects\Values\NullablePlanId;
 use Osiset\ShopifyApp\Contracts\Queries\Plan as IPlanQuery;
@@ -42,7 +43,7 @@ class GetPlanUrl
      * @param IPlanQuery   $planQuery    The querier for the plans.
      * @param IShopQuery   $shopQuery    The querier for shops.
      *
-     * @return self
+     * @return void
      */
     public function __construct(ChargeHelper $chargeHelper, IPlanQuery $planQuery, IShopQuery $shopQuery)
     {
@@ -68,11 +69,27 @@ class GetPlanUrl
         // Get the plan
         $plan = $planId->isNull() ? $this->planQuery->getDefault() : $this->planQuery->getById($planId);
 
-        $api = $shop->apiHelper()->createCharge(
-            ChargeType::fromNative($plan->getType()->toNative()),
-            $this->chargeHelper->details($plan, $shop)
-        );
+        // Confirmation URL
+        $confirmation_url = null;
 
-        return $api['confirmation_url'];
+        switch($plan->getInterval()->toNative()) {
+            case ChargeInterval::ANNUAL()->toNative():
+                $api = $shop->apiHelper()->createChargeGraphQL(
+                    $this->chargeHelper->details($plan, $shop)
+                );
+
+                $confirmation_url = $api['confirmationUrl'];
+                break;
+
+            default:
+                $api = $shop->apiHelper()->createCharge(
+                    ChargeType::fromNative($plan->getType()->toNative()),
+                    $this->chargeHelper->details($plan, $shop)
+                );
+
+                $confirmation_url = $api['confirmation_url'];
+        }
+
+        return $confirmation_url;
     }
 }

--- a/src/ShopifyApp/Contracts/ApiHelper.php
+++ b/src/ShopifyApp/Contracts/ApiHelper.php
@@ -77,9 +77,9 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return ResponseAccess
+     * @return array
      */
-    public function getScriptTags(array $params = []): ResponseAccess;
+    public function getScriptTags(array $params = []): array;
 
     /**
      * Create a script tag for the shop.
@@ -100,9 +100,9 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return ResponseAccess
+     * @return array
      */
-    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess;
+    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): array;
 
     /**
      * Activate a charge.
@@ -110,11 +110,11 @@ interface ApiHelper
      * @param ChargeType      $chargeType The type of charge (plural).
      * @param ChargeReference $chargeRef  The charge ID.
      *
-     * @throws RequestExcpetion
+     * @throws RequestException
      *
-     * @return ResponseAccess
+     * @return array
      */
-    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess;
+    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): array;
 
     /**
      * Create a charge.
@@ -124,7 +124,7 @@ interface ApiHelper
      *
      * @return ResponseAccess
      */
-    public function createCharge(ChargeType $chargeType, PlanDetails $payload): ResponseAccess;
+    public function createCharge(ChargeType $chargeType, PlanDetails $payload): array;
 
     /**
      * Get webhooks for the shop.
@@ -133,18 +133,18 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return ResponseAccess
+     * @return array
      */
-    public function getWebhooks(array $params = []): ResponseAccess;
+    public function getWebhooks(array $params = []): array;
 
     /**
      * Create a webhook.
      *
      * @param array $payload The data for the webhook creation.
      *
-     * @return ResponseAccess
+     * @return array
      */
-    public function createWebhook(array $payload): ResponseAccess;
+    public function createWebhook(array $payload): array;
 
     /**
      * Delete a webhook.

--- a/src/ShopifyApp/Contracts/ApiHelper.php
+++ b/src/ShopifyApp/Contracts/ApiHelper.php
@@ -112,9 +112,9 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return array
+     * @return ResponseAccess
      */
-    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): array;
+    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess;
 
     /**
      * Create a charge.
@@ -124,7 +124,16 @@ interface ApiHelper
      *
      * @return ResponseAccess
      */
-    public function createCharge(ChargeType $chargeType, PlanDetails $payload): array;
+    public function createCharge(ChargeType $chargeType, PlanDetails $payload): ResponseAccess;
+
+    /**
+     * Create a charge using GraphQL.
+     *
+     * @param PlanDetails $payload    The data for the charge creation.
+     *
+     * @return ResponseAccess
+     */
+    public function createChargeGraphQL(PlanDetails $payload): ResponseAccess;
 
     /**
      * Get webhooks for the shop.

--- a/src/ShopifyApp/Contracts/ApiHelper.php
+++ b/src/ShopifyApp/Contracts/ApiHelper.php
@@ -77,9 +77,9 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return array
+     * @return ResponseAccess
      */
-    public function getScriptTags(array $params = []): array;
+    public function getScriptTags(array $params = []): ResponseAccess;
 
     /**
      * Create a script tag for the shop.
@@ -100,9 +100,9 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return array
+     * @return ResponseAccess
      */
-    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): array;
+    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess;
 
     /**
      * Activate a charge.
@@ -142,18 +142,18 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return array
+     * @return ResponseAccess
      */
-    public function getWebhooks(array $params = []): array;
+    public function getWebhooks(array $params = []): ResponseAccess;
 
     /**
      * Create a webhook.
      *
      * @param array $payload The data for the webhook creation.
      *
-     * @return array
+     * @return ResponseAccess
      */
-    public function createWebhook(array $payload): array;
+    public function createWebhook(array $payload): ResponseAccess;
 
     /**
      * Delete a webhook.

--- a/src/ShopifyApp/Contracts/ApiHelper.php
+++ b/src/ShopifyApp/Contracts/ApiHelper.php
@@ -169,7 +169,7 @@ interface ApiHelper
      *
      * @param UsageChargeDetails $payload The data for the usage charge creation.
      *
-     * @return array|bool Array if success, bool for error.
+     * @return ResponseAccess|bool Array if success, bool for error.
      */
     public function createUsageCharge(UsageChargeDetails $payload);
 }

--- a/src/ShopifyApp/Objects/Enums/ApiMethod.php
+++ b/src/ShopifyApp/Objects/Enums/ApiMethod.php
@@ -11,7 +11,7 @@ use Funeralzone\ValueObjects\ValueObject;
  * @method static ApiMethod GET()
  * @method static ApiMethod POST()
  * @method static ApiMethod PUT()
- * @method static ApiMethod DELEE()
+ * @method static ApiMethod DELETE()
  */
 final class ApiMethod implements ValueObject
 {

--- a/src/ShopifyApp/Objects/Enums/ChargeInterval.php
+++ b/src/ShopifyApp/Objects/Enums/ChargeInterval.php
@@ -29,5 +29,4 @@ class ChargeInterval implements ValueObject
      * @var int
      */
     public const ANNUAL = 2;
-
 }

--- a/src/ShopifyApp/Objects/Enums/ChargeInterval.php
+++ b/src/ShopifyApp/Objects/Enums/ChargeInterval.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Class ChargeInterval
+ * @package Osiset\ShopifyApp\Objects\Enums
+ *
+ * @method static ChargeInterval EVERY_30_DAYS()
+ * @method static ChargeInterval ANNUAL()
+ */
+class ChargeInterval implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Interval: Monthly.
+     *
+     * @var int
+     */
+    public const EVERY_30_DAYS = 1;
+
+    /**
+     * Interval: Annual.
+     *
+     * @var int
+     */
+    public const ANNUAL = 2;
+
+}

--- a/src/ShopifyApp/Objects/Enums/ChargeType.php
+++ b/src/ShopifyApp/Objects/Enums/ChargeType.php
@@ -9,6 +9,7 @@ use Funeralzone\ValueObjects\ValueObject;
  * API types for charges.
  *
  * @method static ChargeType RECURRING()
+ * @method static ChargeType CHARGE()
  * @method static ChargeType ONETIME()
  * @method static ChargeType USAGE()
  * @method static ChargeType CREDIT()

--- a/src/ShopifyApp/Objects/Enums/PlanInterval.php
+++ b/src/ShopifyApp/Objects/Enums/PlanInterval.php
@@ -9,8 +9,8 @@ use Funeralzone\ValueObjects\ValueObject;
  * Class PlanInterval
  * @package Osiset\ShopifyApp\Objects\Enums
  *
- * @method static ChargeInterval EVERY_30_DAYS()
- * @method static ChargeInterval ANNUAL()
+ * @method static PlanInterval EVERY_30_DAYS()
+ * @method static PlanInterval ANNUAL()
  */
 class PlanInterval implements ValueObject
 {

--- a/src/ShopifyApp/Objects/Enums/PlanInterval.php
+++ b/src/ShopifyApp/Objects/Enums/PlanInterval.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Class PlanInterval
+ * @package Osiset\ShopifyApp\Objects\Enums
+ *
+ * @method static ChargeInterval EVERY_30_DAYS()
+ * @method static ChargeInterval ANNUAL()
+ */
+class PlanInterval implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Interval: Monthly.
+     *
+     * @var int
+     */
+    public const EVERY_30_DAYS = 1;
+
+    /**
+     * Interval: Annual.
+     *
+     * @var int
+     */
+    public const ANNUAL = 2;
+}

--- a/src/ShopifyApp/Objects/Transfers/PlanDetails.php
+++ b/src/ShopifyApp/Objects/Transfers/PlanDetails.php
@@ -22,6 +22,13 @@ final class PlanDetails extends AbstractTransfer
     public $price;
 
     /**
+     * Plan interval.
+     *
+     * @var string
+     */
+    public $interval;
+
+    /**
      * Plan test or real?
      *
      * @var bool
@@ -69,6 +76,7 @@ final class PlanDetails extends AbstractTransfer
         return [
             'name'          => $this->name,
             'price'         => $this->price,
+            'interval'      => $this->interval,
             'test'          => $this->test,
             'trial_days'    => $this->trialDays,
             'return_url'    => $this->returnUrl,

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -150,7 +150,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function getScriptTags(array $params = []): array
+    public function getScriptTags(array $params = []): ResponseAccess
     {
         // Setup the params
         $reqParams = array_merge(
@@ -189,7 +189,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): array
+    public function getCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess
     {
         // API path
         $typeString = $this->chargeApiPath($chargeType);
@@ -285,7 +285,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function getWebhooks(array $params = []): array
+    public function getWebhooks(array $params = []): ResponseAccess
     {
         // Setup the params
         $reqParams = array_merge(
@@ -309,7 +309,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function createWebhook(array $payload): array
+    public function createWebhook(array $payload): ResponseAccess
     {
         // Fire the request
         $response = $this->doRequest(

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -430,10 +430,11 @@ class ApiHelper implements IApiHelper
         $response = $this->api->graph($query, $payload);
 
         if ($response['errors'] !== false) {
+            $message = isset($response['body']['errors']) && is_array($response['body']['errors'])
+                ? $response['body']['errors'][0]['message'] : 'Unknown error';
+
             // Request error somewhere, throw the exception
-            throw new Exception(
-                isset($response['body']['errors']) && is_array($response['body']['errors']) ? $response['body']['errors'][0]['message'] : 'Unknown error'
-            );
+            throw new Exception($message);
         }
 
         return $response;

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -351,7 +351,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function createUsageCharge(UsageChargeDetailsTransfer $payload): array
+    public function createUsageCharge(UsageChargeDetailsTransfer $payload)
     {
         // Fire the request
         $response = $this->doRequest(
@@ -365,7 +365,8 @@ class ApiHelper implements IApiHelper
             ]
         );
 
-        return $response['body']['usage_charge'];
+        return isset($response['body']) && isset($response['body']['usage_charge'])
+            ? $response['body']['usage_charge'] : false;
     }
 
     /**

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -240,6 +240,7 @@ class ApiHelper implements IApiHelper
 
     /**
      * {@inheritdoc}
+     * @throws Exception
      */
     public function createChargeGraphQL(PlanDetailsTransfer $payload): ResponseAccess
     {

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -245,8 +245,20 @@ class ApiHelper implements IApiHelper
     public function createChargeGraphQL(PlanDetailsTransfer $payload): ResponseAccess
     {
         $query = '
-        mutation appSubscriptionCreate($name: String!, $returnUrl: URL!, $trialDays: Int, $test: Boolean, $lineItems: [AppSubscriptionLineItemInput!]!) {
-            appSubscriptionCreate(name: $name, returnUrl: $returnUrl, trialDays: $trialDays, test: $test, lineItems: $lineItems) {
+        mutation appSubscriptionCreate(
+            $name: String!,
+            $returnUrl: URL!,
+            $trialDays: Int,
+            $test: Boolean,
+            $lineItems: [AppSubscriptionLineItemInput!]!
+        ) {
+            appSubscriptionCreate(
+                name: $name,
+                returnUrl: $returnUrl,
+                trialDays: $trialDays,
+                test: $test,
+                lineItems: $lineItems
+            ) {
                 appSubscription {
                     id
                 }

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -206,7 +206,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): array
+    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess
     {
         // API path
         $typeString = $this->chargeApiPath($chargeType);
@@ -223,7 +223,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function createCharge(ChargeType $chargeType, PlanDetailsTransfer $payload): array
+    public function createCharge(ChargeType $chargeType, PlanDetailsTransfer $payload): ResponseAccess
     {
         // API path
         $typeString = $this->chargeApiPath($chargeType);
@@ -241,7 +241,7 @@ class ApiHelper implements IApiHelper
     /**
      * {@inheritdoc}
      */
-    public function createChargeGraphQL(PlanDetailsTransfer $payload): array
+    public function createChargeGraphQL(PlanDetailsTransfer $payload): ResponseAccess
     {
         $query = '
         mutation appSubscriptionCreate($name: String!, $returnUrl: URL!, $trialDays: Int, $test: Boolean, $lineItems: [AppSubscriptionLineItemInput!]!) {
@@ -270,6 +270,7 @@ class ApiHelper implements IApiHelper
                                 "amount" => $payload->price,
                                 "currencyCode" => "USD",
                             ],
+                            "interval" => $payload->interval
                         ],
                     ]
                 ]

--- a/src/ShopifyApp/Services/ChargeHelper.php
+++ b/src/ShopifyApp/Services/ChargeHelper.php
@@ -42,7 +42,7 @@ class ChargeHelper
      *
      * @param IChargeQuery $chargeQuery The querier for charges.
      *
-     * @return self
+     * @return void
      */
     public function __construct(IChargeQuery $chargeQuery)
     {
@@ -79,7 +79,7 @@ class ChargeHelper
      *
      * @param IShopModel $shop The shop.
      *
-     * @return object
+     * @return array
      */
     public function retrieve(IShopModel $shop)
     {
@@ -261,6 +261,7 @@ class ChargeHelper
         $transfer = new PlanDetailsTransfer();
         $transfer->name = $plan->name;
         $transfer->price = $plan->price;
+        $transfer->interval = $plan->getInterval()->toNative();
         $transfer->test = $plan->isTest();
         $transfer->trialDays = $this->determineTrialDaysRemaining($plan, $shop);
         $transfer->cappedAmount = $isCapped ? $plan->capped_amount : null;

--- a/src/ShopifyApp/Storage/Commands/Charge.php
+++ b/src/ShopifyApp/Storage/Commands/Charge.php
@@ -57,6 +57,7 @@ class Charge implements ChargeCommand
         $charge->status = $chargeObj->chargeStatus->toNative();
         $charge->name = $chargeObj->planDetails->name;
         $charge->price = $chargeObj->planDetails->price;
+        $charge->interval = $chargeObj->planDetails->interval;
         $charge->test = $chargeObj->planDetails->test;
         $charge->trial_days = $chargeObj->planDetails->trialDays;
         $charge->capped_amount = $chargeObj->planDetails->cappedAmount;

--- a/src/ShopifyApp/Storage/Models/Plan.php
+++ b/src/ShopifyApp/Storage/Models/Plan.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Storage\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Osiset\ShopifyApp\Objects\Enums\PlanInterval;
 use Osiset\ShopifyApp\Objects\Enums\PlanType;
 use Osiset\ShopifyApp\Objects\Values\PlanId;
 
@@ -55,9 +56,19 @@ class Plan extends Model
     }
 
     /**
+     * Gets the interval of plan
+     *
+     * @return PlanInterval
+     */
+    public function getInterval(): PlanInterval
+    {
+        return PlanInterval::fromNative($this->interval);
+    }
+
+    /**
      * Checks the plan type.
      *
-     * @param PlamType $type The plan type.
+     * @param PlanType $type The plan type.
      *
      * @return bool
      */

--- a/src/ShopifyApp/Storage/Models/Plan.php
+++ b/src/ShopifyApp/Storage/Models/Plan.php
@@ -62,7 +62,7 @@ class Plan extends Model
      */
     public function getInterval(): PlanInterval
     {
-        return PlanInterval::fromNative($this->interval);
+        return $this->interval ? PlanInterval::fromNative($this->interval) : PlanInterval::EVERY_30_DAYS();
     }
 
     /**

--- a/src/ShopifyApp/resources/database/factories/PlanFactory.php
+++ b/src/ShopifyApp/resources/database/factories/PlanFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Generator as Faker;
+use Osiset\ShopifyApp\Objects\Enums\PlanInterval;
 use Osiset\ShopifyApp\Objects\Enums\PlanType;
 use Osiset\ShopifyApp\Storage\Models\Plan;
 
@@ -34,6 +35,7 @@ $factory->state(Plan::class, 'installable', [
 
 $factory->state(Plan::class, 'type_recurring', [
     'type' => PlanType::RECURRING()->toNative(),
+    'interval' => PlanInterval::EVERY_30_DAYS()->toNative(),
 ]);
 
 $factory->state(Plan::class, 'type_onetime', [

--- a/src/ShopifyApp/resources/database/migrations/2020_07_03_211514_add_interval_column_to_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2020_07_03_211514_add_interval_column_to_charges_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIntervalColumnToChargesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('charges', function (Blueprint $table) {
+            $table->string('interval')->nullable()->after('price');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropColumn('interval');
+        });
+    }
+}

--- a/src/ShopifyApp/resources/database/migrations/2020_07_03_211854_add_interval_column_to_plans_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2020_07_03_211854_add_interval_column_to_plans_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIntervalColumnToPlansTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->string('interval')->nullable()->after('price');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropColumn('interval');
+        });
+    }
+}


### PR DESCRIPTION
Shopify adds an annual subscription to the Billing API in API ver 2020-07, this can only be done with GraphQL API. I added a migration file to add new columns `interval` to the `plans` and `charges` table to flag monthly or annual recurring.

`interval` column accept two values: **EVERY_30_DAYS** or **ANNUAL**. If the interval column is `NULL`, then the interval defaults to **EVERY_30_DAYS**.

Reference:
- [Shopify blog about Release API 2020-07](https://www.shopify.com/partners/blog/shopify-api-release-july-2020#annual-charges)
- [Shopify tutorial to create an annual subscription](https://shopify.dev/tutorials/create-an-annual-subscription)