### PR TITLE
Update ShopModel trait boot method

### DIFF
--- a/src/ShopifyApp/Traits/ShopModel.php
+++ b/src/ShopifyApp/Traits/ShopModel.php
@@ -33,14 +33,14 @@ trait ShopModel
     public $apiHelper;
 
     /**
-     * The "booting" method of the model.
+     * Boot the trait.
+     *
+     * Note that the method boot[TraitName] is auotmatically booted by Laravel
      *
      * @return void
      */
-    protected static function boot(): void
+    protected function bootShopModel(): void
     {
-        parent::boot();
-
         static::addGlobalScope(new Namespacing());
     }
 

--- a/src/ShopifyApp/Traits/ShopModel.php
+++ b/src/ShopifyApp/Traits/ShopModel.php
@@ -35,7 +35,7 @@ trait ShopModel
     /**
      * Boot the trait.
      *
-     * Note that the method boot[TraitName] is auotmatically booted by Laravel
+     * Note that the method boot[TraitName] is auotmatically booted by Laravel.
      *
      * @return void
      */

--- a/src/ShopifyApp/Traits/ShopModel.php
+++ b/src/ShopifyApp/Traits/ShopModel.php
@@ -39,7 +39,7 @@ trait ShopModel
      *
      * @return void
      */
-    protected function bootShopModel(): void
+    protected static function bootShopModel(): void
     {
         static::addGlobalScope(new Namespacing());
     }


### PR DESCRIPTION
This PR simply renames the boot method of the trait `ShopModel` so that this method is not accidentally overriden by a boot method set on the User model. This is done by use of Eloquents automatic boot naming conventions for traits - please see [this guide](https://tighten.co/blog/laravel-tip-bootable-model-traits/] by Tighten Co for more information.

## Without PR:
A `User` model using the `ShopModel` trait might also implement its own `protected static function boot()` which causes the same method on the `ShopModel` trait to be overriden, causing the global scope to **not be** registred.

## With this PR:
A `User` model using the `ShopModel` trait might also implement its own `protected static function boot()` which does not conflict with the `ShopModel` trait since Eloquent will automatically call the method `bootShopModel()` hence causing the global scope to **be** registred when booting the User model.