### PR TITLE
Fix old name for authentication middleware

### DIFF
--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -15,8 +15,8 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     | Home Route
     |--------------------------------------------------------------------------
     |
-    | Homepage for an authenticated store. Store is checked with the auth.shop
-    | middleware and redirected to login if not.
+    | Homepage for an authenticated store. Store is checked with the
+    | auth.shopify middleware and redirected to login if not.
     |
     */
 


### PR DESCRIPTION
Fix the auth middleware name in route comment. The old name for the authentication middleware was `auth.shop` but the new middleware is `auth.shopify`

Note there is no functional changes here, this is solely updating a comment.