### PR TITLE
Fix shopDomain type in php inline doc

### DIFF
--- a/src/ShopifyApp/Console/stubs/webhook-job.stub
+++ b/src/ShopifyApp/Console/stubs/webhook-job.stub
@@ -29,8 +29,8 @@ class DummyClass implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param string   $shopDomain The shop's myshopify domain
-     * @param stdClass $data    The webhook data (JSON decoded)
+     * @param ShopDomain $shopDomain The shop's myshopify domain
+     * @param stdClass   $data       The webhook data (JSON decoded)
      *
      * @return void
      */


### PR DESCRIPTION
`$shopDomain` is not a string but an instance of `Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain`