### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This project is missing a `.editorconfig` file, even though it is referenced here: https://github.com/osiset/laravel-shopify/blob/13511ba9b21adc1941193e94a7ad26fae1ef31c1/.gitattributes#L47