### PR TITLE
Declare missing tests classes properties

### DIFF
--- a/tests/Actions/ActivatePlanTest.php
+++ b/tests/Actions/ActivatePlanTest.php
@@ -12,6 +12,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class ActivatePlanTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\ActivatePlan
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/ActivateUsageChargeTest.php
+++ b/tests/Actions/ActivateUsageChargeTest.php
@@ -13,6 +13,11 @@ use Osiset\ShopifyApp\Objects\Values\ChargeId;
 
 class ActivateUsageChargeTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\ActivateUsageCharge
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/AfterAuthorizeTest.php
+++ b/tests/Actions/AfterAuthorizeTest.php
@@ -10,6 +10,11 @@ require_once __DIR__.'/../Stubs/AfterAuthorizeJob.php';
 
 class AfterAuthorizeTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\AfterAuthorize
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/AuthenticateShopTest.php
+++ b/tests/Actions/AuthenticateShopTest.php
@@ -9,6 +9,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class AuthenticateShopTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\AuthenticateShop
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/AuthorizeShopTest.php
+++ b/tests/Actions/AuthorizeShopTest.php
@@ -9,6 +9,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class AuthorizeShopTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\AuthorizeShop
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/CancelChargeTest.php
+++ b/tests/Actions/CancelChargeTest.php
@@ -11,6 +11,11 @@ use Osiset\ShopifyApp\Storage\Models\Charge;
 
 class CancelChargeTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\CancelCharge
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/CancelCurrentPlanTest.php
+++ b/tests/Actions/CancelCurrentPlanTest.php
@@ -9,6 +9,11 @@ use Osiset\ShopifyApp\Actions\CancelCurrentPlan;
 
 class CancelCurrentPlanTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\CancelCurrentPlan
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/CreateScriptsTest.php
+++ b/tests/Actions/CreateScriptsTest.php
@@ -8,6 +8,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class CreateScriptsTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\CreateScripts
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/CreateWebhooksTest.php
+++ b/tests/Actions/CreateWebhooksTest.php
@@ -8,6 +8,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class CreateWebhooksTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\CreateWebhooks
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/DeleteWebhooksTest.php
+++ b/tests/Actions/DeleteWebhooksTest.php
@@ -8,6 +8,11 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class DeleteWebhooksTestTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\DeleteWebhooks
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/DispatchScriptsTest.php
+++ b/tests/Actions/DispatchScriptsTest.php
@@ -10,6 +10,11 @@ use Osiset\ShopifyApp\Messaging\Jobs\ScripttagInstaller;
 
 class DispatchScriptsTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\DispatchScripts
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/DispatchWebhooksTest.php
+++ b/tests/Actions/DispatchWebhooksTest.php
@@ -10,6 +10,11 @@ use Osiset\ShopifyApp\Messaging\Jobs\WebhookInstaller;
 
 class DispatchWebhooksTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\DispatchWebhooks
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/GetPlanUrlTest.php
+++ b/tests/Actions/GetPlanUrlTest.php
@@ -10,6 +10,11 @@ use Osiset\ShopifyApp\Objects\Values\NullablePlanId;
 
 class GetPlanUrlTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Actions\GetPlanUrl
+     */
+    protected $action;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Http/Middleware/AuthShopifyTest.php
+++ b/tests/Http/Middleware/AuthShopifyTest.php
@@ -12,6 +12,9 @@ use Osiset\ShopifyApp\Services\ShopSession;
 
 class AuthShopifyTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
 
     public function setUp(): void

--- a/tests/Http/Middleware/BillableTest.php
+++ b/tests/Http/Middleware/BillableTest.php
@@ -11,6 +11,9 @@ use Osiset\ShopifyApp\Http\Middleware\Billable as BillableMiddleware;
 
 class BillableTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
 
     public function setUp(): void

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -18,6 +18,9 @@ use Osiset\ShopifyApp\Objects\Transfers\UsageChargeDetails as UsageChargeDetails
 
 class ApiHelperTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\ApiHelper
+     */
     protected $api;
 
     public function setUp(): void

--- a/tests/Services/ChargeHelperTest.php
+++ b/tests/Services/ChargeHelperTest.php
@@ -15,6 +15,9 @@ use stdClass;
 
 class ChargeHelperTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ChargeHelper
+     */
     protected $chargeHelper;
 
     public function setUp(): void

--- a/tests/Services/CookieHelperTest.php
+++ b/tests/Services/CookieHelperTest.php
@@ -7,8 +7,19 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class CookieHelperTest extends TestCase
 {
+    /**
+     * @var array
+     */
     protected $incompatibleUserAgents;
+
+    /**
+     * @var array
+     */
     protected $compatibleUserAgents;
+
+    /**
+     * @var array
+     */
     protected $badUserAgents;
 
     public function setUp(): void

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -10,8 +10,10 @@ use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 
 class ShopSessionTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
-    protected $model;
 
     public function setUp(): void
     {

--- a/tests/Storage/Commands/ChargeTest.php
+++ b/tests/Storage/Commands/ChargeTest.php
@@ -18,6 +18,9 @@ use Osiset\ShopifyApp\Objects\Transfers\UsageChargeDetails as UsageChargeDetails
 
 class ChargeTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\Commands\Charge
+     */
     protected $command;
 
     public function setUp(): void

--- a/tests/Storage/Commands/ShopTest.php
+++ b/tests/Storage/Commands/ShopTest.php
@@ -11,6 +11,9 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class ShopTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\Commands\Shop
+     */
     protected $command;
 
     public function setUp(): void

--- a/tests/Storage/Queries/ChargeTest.php
+++ b/tests/Storage/Queries/ChargeTest.php
@@ -11,7 +11,14 @@ use Osiset\ShopifyApp\Contracts\Queries\Charge as IChargeQuery;
 
 class ChargeTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\Queries\Charge
+     */
     protected $query;
+
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
     protected $shop;
 
     public function setUp(): void

--- a/tests/Storage/Queries/PlanTest.php
+++ b/tests/Storage/Queries/PlanTest.php
@@ -9,6 +9,9 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class PlanTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\Queries\Plan
+     */
     protected $query;
 
     public function setUp(): void

--- a/tests/Storage/Queries/ShopTest.php
+++ b/tests/Storage/Queries/ShopTest.php
@@ -9,6 +9,9 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class ShopTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\Queries\Shop
+     */
     protected $query;
 
     public function setUp(): void

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -9,6 +9,9 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class AuthControllerTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
 
     public function setUp(): void

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -11,6 +11,9 @@ use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 
 class BillingControllerTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
 
     public function setUp(): void

--- a/tests/Traits/HomeControllerTest.php
+++ b/tests/Traits/HomeControllerTest.php
@@ -7,6 +7,9 @@ use Osiset\ShopifyApp\Services\ShopSession;
 
 class HomeControllerTest extends TestCase
 {
+    /**
+     * @var \Osiset\ShopifyApp\Services\ShopSession
+     */
     protected $shopSession;
 
     public function setUp(): void


### PR DESCRIPTION
Declare missing tests classes properties, and also add their docblocks if they are missing.