### PR TITLE
Updated composer.json to support legacy factories for Orchestra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.8",
+        "laravel/legacy-factories": "^1.0.4",
         "mockery/mockery": "^1.0",
         "orchestra/database": "~3.8 || ~4.0 || ~5.0 || ~6.0",
         "orchestra/testbench": "~3.8 || ~4.0 || ~5.0 || ~6.0",


### PR DESCRIPTION
Based on information from https://github.com/orchestral/testbench/blob/6.x/README.md#using-legacy-factories

Unit tests for Laravel 8.1 are passing locally.