### PR TITLE
Ability to override internal routes #596

### DIFF
--- a/src/ShopifyApp/helpers.php
+++ b/src/ShopifyApp/helpers.php
@@ -95,5 +95,5 @@ function parseQueryString(string $qs, string $d = null): array
  */
 function registerPackageRoute(string $routeName, $routes): bool
 {
-    return !(is_array($routes) && in_array($routeName, $routes));
+    return ! (is_array($routes) && in_array($routeName, $routes));
 }

--- a/src/ShopifyApp/helpers.php
+++ b/src/ShopifyApp/helpers.php
@@ -84,3 +84,16 @@ function parseQueryString(string $qs, string $d = null): array
 
     return $params;
 }
+
+/**
+ * Checks if the route should be registered or not.
+ *
+ * @param string     $routeName The route name to check.
+ * @param bool|array $routes    The routes which are to be excluded.
+ *
+ * @return bool
+ */
+function registerPackageRoute(string $routeName, $routes): bool
+{
+    return !(is_array($routes) && in_array($routeName, $routes));
+}

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -25,6 +25,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Manual routes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to ignore the package's built-in routes.
+    | Use `false` (default) for allowing the built-in routes. Otherwise, you
+    | can list out which route "names" you would like excluded.
+    | See `resources/routes.php` for list of route names available.
+    | Example: `home,billing` would ignore both "home" and "billing" routes.
+    |
+    */
+    'manual_routes' => (bool) env('SHOPIFY_MANUAL_ROUTES', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Namespace
     |--------------------------------------------------------------------------
     |

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -35,7 +35,7 @@ return [
     | Example: `home,billing` would ignore both "home" and "billing" routes.
     |
     */
-    'manual_routes' => (bool) env('SHOPIFY_MANUAL_ROUTES', false),
+    'manual_routes' => env('SHOPIFY_MANUAL_ROUTES', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -9,7 +9,29 @@
 |
 */
 
-Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']], function () {
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Config;
+
+// Check if manual routes override is to be use
+$manualRoutes = Config::get('shopify-app.manual_routes');
+if ($manualRoutes) {
+    // Get a list of route names to exclude
+    $manualRoutes = explode(',', $manualRoutes);
+}
+
+/**
+ * Checks if the route should be registered or not.
+ *
+ * @param string     $routeName
+ * @param bool|array $routes
+ *
+ * @return bool
+ */
+function registerPackageRoute(string $routeName, $routes): bool {
+    return !(is_array($routes) && in_array($routeName, $routes));
+}
+
+Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | Home Route
@@ -20,12 +42,14 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::get(
-        '/',
-        'Osiset\ShopifyApp\Http\Controllers\HomeController@index'
-    )
-    ->middleware(['auth.shopify', 'billable'])
-    ->name('home');
+    if (registerPackageRoute('home', $manualRoutes)) {
+        Route::get(
+            '/',
+            'Osiset\ShopifyApp\Http\Controllers\HomeController@index'
+        )
+        ->middleware(['auth.shopify', 'billable'])
+        ->name('home');
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -36,12 +60,14 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::match(
-        ['get', 'post'],
-        '/authenticate',
-        'Osiset\ShopifyApp\Http\Controllers\AuthController@authenticate'
-    )
-    ->name('authenticate');
+    if (registerPackageRoute('authenticate', $manualRoutes)) {
+        Route::match(
+            ['get', 'post'],
+            '/authenticate',
+            'Osiset\ShopifyApp\Http\Controllers\AuthController@authenticate'
+        )
+        ->name('authenticate');
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -52,11 +78,13 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::get(
-        '/authenticate/oauth',
-        'Osiset\ShopifyApp\Http\Controllers\AuthController@oauth'
-    )
-    ->name('authenticate.oauth');
+    if (registerPackageRoute('authenticate.oauth', $manualRoutes)) {
+        Route::get(
+            '/authenticate/oauth',
+            'Osiset\ShopifyApp\Http\Controllers\AuthController@oauth'
+        )
+        ->name('authenticate.oauth');
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -67,13 +95,15 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::get(
-        '/billing/{plan?}',
-        'Osiset\ShopifyApp\Http\Controllers\BillingController@index'
-    )
-    ->middleware(['auth.shopify'])
-    ->where('plan', '^([0-9]+|)$')
-    ->name('billing');
+    if (registerPackageRoute('billing', $manualRoutes)) {
+        Route::get(
+            '/billing/{plan?}',
+            'Osiset\ShopifyApp\Http\Controllers\BillingController@index'
+        )
+        ->middleware(['auth.shopify'])
+        ->where('plan', '^([0-9]+|)$')
+        ->name('billing');
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -84,13 +114,15 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::get(
-        '/billing/process/{plan?}',
-        'Osiset\ShopifyApp\Http\Controllers\BillingController@process'
-    )
-    ->middleware(['auth.shopify'])
-    ->where('plan', '^([0-9]+|)$')
-    ->name('billing.process');
+    if (registerPackageRoute('billing.process', $manualRoutes)) {
+        Route::get(
+            '/billing/process/{plan?}',
+            'Osiset\ShopifyApp\Http\Controllers\BillingController@process'
+        )
+        ->middleware(['auth.shopify'])
+        ->where('plan', '^([0-9]+|)$')
+        ->name('billing.process');
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -101,16 +133,18 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
     |
     */
 
-    Route::match(
-        ['get', 'post'],
-        '/billing/usage-charge',
-        'Osiset\ShopifyApp\Http\Controllers\BillingController@usageCharge'
-    )
-    ->middleware(['auth.shopify'])
-    ->name('billing.usage_charge');
+    if (registerPackageRoute('billing.usage_charge', $manualRoutes)) {
+        Route::match(
+            ['get', 'post'],
+            '/billing/usage-charge',
+            'Osiset\ShopifyApp\Http\Controllers\BillingController@usageCharge'
+        )
+        ->middleware(['auth.shopify'])
+        ->name('billing.usage_charge');
+    }
 });
 
-Route::group(['middleware' => ['api']], function () {
+Route::group(['middleware' => ['api']], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | Webhook Handler
@@ -120,10 +154,12 @@ Route::group(['middleware' => ['api']], function () {
     |
     */
 
-    Route::post(
-        '/webhook/{type}',
-        'Osiset\ShopifyApp\Http\Controllers\WebhookController@handle'
-    )
-    ->middleware('auth.webhook')
-    ->name('webhook');
+    if (registerPackageRoute('webhook', $manualRoutes)) {
+        Route::post(
+            '/webhook/{type}',
+            'Osiset\ShopifyApp\Http\Controllers\WebhookController@handle'
+        )
+        ->middleware('auth.webhook')
+        ->name('webhook');
+    }
 });

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -19,16 +19,19 @@ if ($manualRoutes) {
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-/**
- * Checks if the route should be registered or not.
- *
- * @param string     $routeName
- * @param bool|array $routes
- *
- * @return bool
- */
-function registerPackageRoute(string $routeName, $routes): bool {
-    return !(is_array($routes) && in_array($routeName, $routes));
+if (!function_exists('registerPackageRoutes')) {
+    /**
+     * Checks if the route should be registered or not.
+     *
+     * @param string     $routeName
+     * @param bool|array $routes
+     *
+     * @return bool
+     */
+    function registerPackageRoute(string $routeName, $routes): bool
+    {
+        return !(is_array($routes) && in_array($routeName, $routes));
+    }
 }
 
 Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -9,8 +9,8 @@
 |
 */
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
 use function Osiset\ShopifyApp\registerPackageRoute;
 
 // Check if manual routes override is to be use

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -11,27 +11,13 @@
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Config;
+use function Osiset\ShopifyApp\registerPackageRoute;
 
 // Check if manual routes override is to be use
 $manualRoutes = Config::get('shopify-app.manual_routes');
 if ($manualRoutes) {
     // Get a list of route names to exclude
     $manualRoutes = explode(',', $manualRoutes);
-}
-
-if (!function_exists('registerPackageRoutes')) {
-    /**
-     * Checks if the route should be registered or not.
-     *
-     * @param string     $routeName
-     * @param bool|array $routes
-     *
-     * @return bool
-     */
-    function registerPackageRoute(string $routeName, $routes): bool
-    {
-        return !(is_array($routes) && in_array($routeName, $routes));
-    }
 }
 
 Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -32,4 +32,13 @@ class HelpersTest extends TestCase
             createHmac(['data' => $data, 'buildQuery' => true], $secret)
         );
     }
+
+    public function testRegisterPackageRoutes(): void
+    {
+        // Routes to exclude
+        $routes = explode(',', 'home,billing');
+
+        $this->assertTrue(registerPackageRoute('authenticate', $routes));
+        $this->assertFalse(registerPackageRoute('home', $routes));
+    }
 }


### PR DESCRIPTION
Relates to #596, needs physical testing.

Allows for someone to list out routes they wish to be excluded from registering with Laravel.

Example: `SHOPIFY_MANUAL_ROUTES=home,billing` would tell this package to not register the internal `home` and `billing` routes.