### PR TITLE
Make route names configurable

### DIFF
--- a/src/ShopifyApp/Http/Middleware/AuthShopify.php
+++ b/src/ShopifyApp/Http/Middleware/AuthShopify.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -14,12 +15,15 @@ use Osiset\ShopifyApp\Objects\Enums\DataSource;
 use Osiset\ShopifyApp\Objects\Values\NullShopDomain;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Services\ShopSession;
+use Osiset\ShopifyApp\Traits\ConfigAccessible;
 
 /**
  * Response for ensuring an authenticated request.
  */
 class AuthShopify
 {
+    use ConfigAccessible;
+
     /**
      * The API helper.
      *
@@ -328,7 +332,7 @@ class AuthShopify
      *
      * @throws MissingShopDomainException
      *
-     * @return void
+     * @return RedirectResponse
      */
     private function handleBadVerification(Request $request, ShopDomainValue $domain)
     {
@@ -345,7 +349,7 @@ class AuthShopify
 
         // Mis-match of shops
         return Redirect::route(
-            'authenticate.oauth',
+            $this->getConfig('route_names.authenticate.oauth'),
             ['shop' => $domain->toNative()]
         );
     }

--- a/src/ShopifyApp/Http/Middleware/Billable.php
+++ b/src/ShopifyApp/Http/Middleware/Billable.php
@@ -48,7 +48,7 @@ class Billable
             $shop = $this->shopSession->getShop();
             if (! $shop->isFreemium() && ! $shop->isGrandfathered() && ! $shop->plan) {
                 // They're not grandfathered in, and there is no charge or charge was declined... redirect to billing
-                return Redirect::route('billing', $request->input());
+                return Redirect::route($this->getConfig('route_names.billing'), $request->input());
             }
         }
 

--- a/src/ShopifyApp/Services/ConfigHelper.php
+++ b/src/ShopifyApp/Services/ConfigHelper.php
@@ -5,7 +5,7 @@ namespace Osiset\ShopifyApp\Services;
 use Osiset\ShopifyApp\Traits\ConfigAccessible;
 
 /**
- * Basic helper class to set/get config values
+ * Basic helper class to set/get config values.
  *
  * This allows you to use the `ConfigAccessible` trait methods in situations where
  * you are unable to use the trait because you are not in a class scope

--- a/src/ShopifyApp/Services/ConfigHelper.php
+++ b/src/ShopifyApp/Services/ConfigHelper.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Osiset\ShopifyApp\Services;
+
+use Osiset\ShopifyApp\Traits\ConfigAccessible;
+
+/**
+ * Basic helper class to set/get config values
+ *
+ * This allows you to use the `ConfigAccessible` trait methods in situations where
+ * you are unable to use the trait because you are not in a class scope
+ * (e.g. when defining routes)
+ */
+class ConfigHelper
+{
+    use ConfigAccessible;
+
+    /**
+     * Get the config value for a key.
+     *
+     * @param string $key The key to lookup.
+     *
+     * @return mixed
+     *
+     * @see \Osiset\ShopifyApp\Traits\ConfigAccessible::getConfig()
+     */
+    public static function get(string $key)
+    {
+        return (new static)->getConfig($key);
+    }
+
+    /**
+     * Sets a config value for a key.
+     *
+     * @param string $key   The key to use.
+     * @param mixed  $value The value to set.
+     *
+     * @return void
+     *
+     * @see \Osiset\ShopifyApp\Traits\ConfigAccessible::setConfig()
+     */
+    public static function set(string $key, $value): void
+    {
+        (new static)->setConfig($key, $value);
+    }
+
+    /**
+     * Set multiple config values.
+     *
+     * @param array|mixed[] $kvs
+     *
+     * @return void
+     *
+     * @see \Osiset\ShopifyApp\Traits\ConfigAccessible::setConfigArray()
+     */
+    public static function setArray(array $kvs): void
+    {
+        (new static)->setConfigArray($kvs);
+    }
+}

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -18,6 +18,8 @@ use Osiset\ShopifyApp\Objects\Values\ShopDomain;
  */
 trait AuthController
 {
+    use ConfigAccessible;
+
     /**
      * Authenticating a shop.
      *
@@ -51,7 +53,7 @@ trait AuthController
             }
 
             // No return_to, go to home route
-            return Redirect::route('home');
+            return Redirect::route($this->getConfig('route_names.home'));
         }
     }
 

--- a/src/ShopifyApp/Traits/BillingController.php
+++ b/src/ShopifyApp/Traits/BillingController.php
@@ -22,6 +22,8 @@ use Osiset\ShopifyApp\Services\ShopSession;
  */
 trait BillingController
 {
+    use ConfigAccessible;
+
     /**
      * Redirects to billing screen for Shopify.
      *
@@ -70,7 +72,7 @@ trait BillingController
         );
 
         // Go to homepage of app
-        return Redirect::route('home')->with(
+        return Redirect::route($this->getConfig('route_names.home'))->with(
             $result ? 'success' : 'failure',
             'billing'
         );

--- a/src/ShopifyApp/Traits/ConfigAccessible.php
+++ b/src/ShopifyApp/Traits/ConfigAccessible.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Traits;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 /**
  * Allows for getting of config data easily for the package.
@@ -24,6 +25,17 @@ trait ConfigAccessible
             ['user_model' => Config::get('auth.providers.users.model')]
         );
 
+        if (Str::is('route_names.*', $key)) {
+            // scope the Arr::get() call to the "route_names" array
+            // to allow for dot-notation keys like "authenticate.oauth"
+            // this is necessary because Arr::get() only finds dot-notation keys
+            // if they are at the top level of the given array
+            return Arr::get(
+                $this->config['route_names'],
+                Str::after($key, '.')
+            );
+        }
+
         return Arr::get($this->config, $key);
     }
 
@@ -40,6 +52,13 @@ trait ConfigAccessible
         Config::set($key, $value);
     }
 
+    /**
+     * Set multiple config values.
+     *
+     * @param array|mixed[] $kvs
+     *
+     * @return void
+     */
     public function setConfigArray(array $kvs): void
     {
         foreach ($kvs as $key => $value) {

--- a/src/ShopifyApp/Traits/ConfigAccessible.php
+++ b/src/ShopifyApp/Traits/ConfigAccessible.php
@@ -2,6 +2,7 @@
 
 namespace Osiset\ShopifyApp\Traits;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -23,7 +24,7 @@ trait ConfigAccessible
             ['user_model' => Config::get('auth.providers.users.model')]
         );
 
-        return $this->config[$key];
+        return Arr::get($this->config, $key);
     }
 
     /**

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -31,11 +31,34 @@ return [
     | This option allows you to ignore the package's built-in routes.
     | Use `false` (default) for allowing the built-in routes. Otherwise, you
     | can list out which route "names" you would like excluded.
-    | See `resources/routes.php` for list of route names available.
+    | See `resources/routes/shopify.php` and `resources/routes/api.php`
+    | for a list of available route names.
     | Example: `home,billing` would ignore both "home" and "billing" routes.
+    |
+    | Please note that if you override the route names (see "route_names" below),
+    | the route names that are used in this option DO NOT change!
     |
     */
     'manual_routes' => env('SHOPIFY_MANUAL_ROUTES', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route names
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to override the package's built-in route names.
+    | This can help you avoid collisions with your existing route names.
+    |
+    */
+    'route_names' => [
+        'home' => env('SHOPIFY_ROUTE_NAME_HOME', 'home'),
+        'authenticate' => env('SHOPIFY_ROUTE_NAME_AUTHENTICATE', 'authenticate'),
+        'authenticate.oauth' => env('SHOPIFY_ROUTE_NAME_AUTHENTICATE_OAUTH', 'authenticate.oauth'),
+        'billing' => env('SHOPIFY_ROUTE_NAME_BILLING', 'billing'),
+        'billing.process' => env('SHOPIFY_ROUTE_NAME_BILLING_PROCESS', 'billing.process'),
+        'billing.usage_charge' => env('SHOPIFY_ROUTE_NAME_BILLING_USAGE_CHARGE', 'billing.usage_charge'),
+        'webhook' => env('SHOPIFY_ROUTE_NAME_WEBHOOK', 'webhook'),
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/ShopifyApp/resources/routes/api.php
+++ b/src/ShopifyApp/resources/routes/api.php
@@ -1,11 +1,11 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
+use Osiset\ShopifyApp\Services\ConfigHelper;
 use function Osiset\ShopifyApp\registerPackageRoute;
 
 // Check if manual routes override is to be use
-$manualRoutes = Config::get('shopify-app.manual_routes');
+$manualRoutes = ConfigHelper::get('manual_routes');
 
 if ($manualRoutes) {
     // Get a list of route names to exclude
@@ -56,6 +56,6 @@ Route::group(['middleware' => ['api']], function ($manualRoutes) {
             'Osiset\ShopifyApp\Http\Controllers\WebhookController@handle'
         )
         ->middleware('auth.webhook')
-        ->name('webhook');
+        ->name(ConfigHelper::get('route_names.webhook'));
     }
 });

--- a/src/ShopifyApp/resources/routes/api.php
+++ b/src/ShopifyApp/resources/routes/api.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Osiset\ShopifyApp\Services\ConfigHelper;
 use function Osiset\ShopifyApp\registerPackageRoute;
+use Osiset\ShopifyApp\Services\ConfigHelper;
 
 // Check if manual routes override is to be use
 $manualRoutes = ConfigHelper::get('manual_routes');

--- a/src/ShopifyApp/resources/routes/shopify.php
+++ b/src/ShopifyApp/resources/routes/shopify.php
@@ -10,8 +10,8 @@
 */
 
 use Illuminate\Support\Facades\Route;
-use Osiset\ShopifyApp\Services\ConfigHelper;
 use function Osiset\ShopifyApp\registerPackageRoute;
+use Osiset\ShopifyApp\Services\ConfigHelper;
 
 // Check if manual routes override is to be use
 $manualRoutes = ConfigHelper::get('manual_routes');

--- a/src/ShopifyApp/resources/routes/shopify.php
+++ b/src/ShopifyApp/resources/routes/shopify.php
@@ -9,19 +9,19 @@
 |
 */
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
+use Osiset\ShopifyApp\Services\ConfigHelper;
 use function Osiset\ShopifyApp\registerPackageRoute;
 
 // Check if manual routes override is to be use
-$manualRoutes = Config::get('shopify-app.manual_routes');
+$manualRoutes = ConfigHelper::get('manual_routes');
 
 if ($manualRoutes) {
     // Get a list of route names to exclude
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {
+Route::group(['prefix' => ConfigHelper::get('prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | Home Route
@@ -38,7 +38,7 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
             'Osiset\ShopifyApp\Http\Controllers\HomeController@index'
         )
         ->middleware(['auth.shopify', 'billable'])
-        ->name('home');
+        ->name(ConfigHelper::get('route_names.home'));
     }
 
     /*
@@ -56,7 +56,7 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
             '/authenticate',
             'Osiset\ShopifyApp\Http\Controllers\AuthController@authenticate'
         )
-        ->name('authenticate');
+        ->name(ConfigHelper::get('route_names.authenticate'));
     }
 
     /*
@@ -73,7 +73,7 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
             '/authenticate/oauth',
             'Osiset\ShopifyApp\Http\Controllers\AuthController@oauth'
         )
-        ->name('authenticate.oauth');
+        ->name(ConfigHelper::get('route_names.authenticate.oauth'));
     }
 
     /*
@@ -92,7 +92,7 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
         )
         ->middleware(['auth.shopify'])
         ->where('plan', '^([0-9]+|)$')
-        ->name('billing');
+        ->name(ConfigHelper::get('route_names.billing'));
     }
 
     /*
@@ -111,7 +111,7 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
         )
         ->middleware(['auth.shopify'])
         ->where('plan', '^([0-9]+|)$')
-        ->name('billing.process');
+        ->name(ConfigHelper::get('route_names.billing.process'));
     }
 
     /*
@@ -130,6 +130,6 @@ Route::group(['prefix' => config('shopify-app.prefix'), 'middleware' => ['web']]
             'Osiset\ShopifyApp\Http\Controllers\BillingController@usageCharge'
         )
         ->middleware(['auth.shopify'])
-        ->name('billing.usage_charge');
+        ->name(ConfigHelper::get('route_names.billing.usage_charge'));
     }
 });

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -2,6 +2,7 @@
 
 namespace Osiset\ShopifyApp;
 
+use Osiset\ShopifyApp\Services\ConfigHelper;
 use Osiset\ShopifyApp\Test\TestCase;
 
 class HelpersTest extends TestCase
@@ -40,5 +41,20 @@ class HelpersTest extends TestCase
 
         $this->assertTrue(registerPackageRoute('authenticate', $routes));
         $this->assertFalse(registerPackageRoute('home', $routes));
+    }
+
+    public function testRouteNames(): void
+    {
+        // non-dot-notation route name
+        $this->assertSame(
+            ConfigHelper::get('route_names.home'),
+            'home'
+        );
+
+        // dot-notation route name
+        $this->assertSame(
+            ConfigHelper::get('route_names.authenticate.oauth'),
+            'authenticate.oauth'
+        );
     }
 }


### PR DESCRIPTION
This implements the changes we discussed in #595. All route names can be configured through either the config file or through environment variables.

You mentioned `ConfigAccessible`, which is a huge help. However, given that it's a trait and only accessible in a class scope, I created a simple `ConfigHelper` wrapper class that has static `get()`, `set()`, and `setArray()` methods. This lets you use `ConfigAccessible` everywhere, regardless of scope. I used it in `resources/routes/shopify.php` and `resources/routes/api.php` to get `manual_routes` and `prefix`, as well as all of the route names.

An additional reason for creating `ConfigHelper` was because I had to add some additional logic to `ConfigAccessible->get()` to support dot-notation in the keys for the route names in the config file. Laravel's `config()` helper wouldn't handle it. I originally was planning on doing underscores (e.g. `billing_usage_charge`) but I think the consistency between the keys and the default route names (e.g. `billing.usage_charge`) will help prevent any confusion.

There weren't any route-specific tests, so I created a simple one to test non-dot-notation route name keys and dot-notation route name keys. It's more of a `ConfigAccessible` test than a route name test, but it does the trick either way!

Let me know your thoughts or if you have any feedback or changes you'd like me to make. Thanks!