### PR TITLE
Hotfix exclude api register routes

### DIFF
--- a/src/ShopifyApp/helpers.php
+++ b/src/ShopifyApp/helpers.php
@@ -118,12 +118,24 @@ function base64url_decode($data)
 /**
  * Checks if the route should be registered or not.
  *
- * @param string     $routeName The route name to check.
- * @param bool|array $routes    The routes which are to be excluded.
+ * @param string     $routeToCheck The route name to check.
+ * @param bool|array $routesToExclude The routes which are to be excluded.
  *
  * @return bool
  */
-function registerPackageRoute(string $routeName, $routes): bool
+function registerPackageRoute(string $routeToCheck, $routesToExclude): bool
 {
-    return ! (is_array($routes) && in_array($routeName, $routes));
+    if ($routesToExclude === false) {
+        return true;
+    }
+
+    if ($routesToExclude === true) {
+        throw new \LogicException('Excluded routes can be false, or an array');
+    }
+
+    if (is_array($routesToExclude) === false) {
+        throw new \LogicException('Excluded routes must be an array');
+    }
+
+    return in_array($routeToCheck, $routesToExclude, true) === false;
 }

--- a/src/ShopifyApp/resources/routes/api.php
+++ b/src/ShopifyApp/resources/routes/api.php
@@ -12,7 +12,7 @@ if ($manualRoutes) {
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-Route::group(['middleware' => ['api']], function ($manualRoutes) {
+Route::group(['middleware' => ['api']], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | API Routes

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -39,8 +39,13 @@ class HelpersTest extends TestCase
         // Routes to exclude
         $routes = explode(',', 'home,billing');
 
+        $this->assertTrue(registerPackageRoute('authenticate', false));
+        $this->assertTrue(registerPackageRoute('authenticate', []));
         $this->assertTrue(registerPackageRoute('authenticate', $routes));
         $this->assertFalse(registerPackageRoute('home', $routes));
+
+        $this->expectErrorMessage('Excluded routes must be an array');
+        registerPackageRoute('home', \stdClass::class);
     }
 
     public function testRouteNames(): void


### PR DESCRIPTION
There was a bug in the code that made it impossible to exclude "api" routes using configuration. In addition, the Router class got into the function, I modified the function so that it could not happen in the future.