### PR TITLE
Pass session into api_init function

### DIFF
--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -49,7 +49,11 @@ class ApiHelper implements IApiHelper
         // Create the instance
         if ($this->getConfig('api_init')) {
             // User-defined init function
-            $this->api = call_user_func($this->getConfig('api_init'), $opts);
+            $this->api = call_user_func(
+                $this->getConfig('api_init'),
+                $opts,
+                $session
+            );
         } else {
             // Default init
             $ts = $this->getConfig('api_time_store');

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -233,7 +233,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option is for initing the BasicShopifyAPI package optionally yourself.
-    | The first param injected in the current options (\Osiset\BasicShopifyAPI\Options).
+    | The first param injected in is the current options (\Osiset\BasicShopifyAPI\Options).
+    | The second param injected in is the session (if available) (\Osiset\BasicShopifyAPI\Session).
     | With this, you can customize the options, change params, and more.
     |
     | Value for this option must be a callable (callable, Closure, etc).


### PR DESCRIPTION
Reasoning behind this is to allow for using "Custom Apps" with the same code base. One could add a migration to the users table to store the custom app api key/secret for each shop, then in the config, utilize api_init option to pull the keys from the database for the shop.

This has been requested many times since Shopify now limits how apps work, you can not have an unpublished app installed on many stores. This "solution" will allow for same code base, and switching the API keys on the fly when the API interface is requested for the shop.