### PR TITLE
Fix to remove job class from arguments passed to job

### DIFF
--- a/src/ShopifyApp/Actions/DispatchScripts.php
+++ b/src/ShopifyApp/Actions/DispatchScripts.php
@@ -28,26 +28,17 @@ class DispatchScripts
     protected $jobClass;
 
     /**
-     * The action to handle the job.
-     *
-     * @var callable
-     */
-    protected $actionClass;
-
-    /**
      * Setup.
      *
-     * @param IShopQuery $shopQuery   The querier for the shop.
-     * @param string     $jobClass    The job to dispatch.
-     * @param callable   $actionClass The action to handle the job.
+     * @param IShopQuery $shopQuery The querier for the shop.
+     * @param string     $jobClass  The job to dispatch.
      *
      * @return void
      */
-    public function __construct(IShopQuery $shopQuery, string $jobClass, callable $actionClass)
+    public function __construct(IShopQuery $shopQuery, string $jobClass)
     {
         $this->shopQuery = $shopQuery;
         $this->jobClass = $jobClass;
-        $this->actionClass = $actionClass;
     }
 
     /**
@@ -74,13 +65,11 @@ class DispatchScripts
         if ($inline) {
             ($this->jobClass)::dispatchNow(
                 $shop->getId(),
-                $this->actionClass,
                 $scripttags
             );
         } else {
             ($this->jobClass)::dispatch(
                 $shop->getId(),
-                $this->actionClass,
                 $scripttags
             )->onQueue($this->getConfig('job_queues')['scripttags']);
         }

--- a/src/ShopifyApp/Actions/DispatchWebhooks.php
+++ b/src/ShopifyApp/Actions/DispatchWebhooks.php
@@ -28,26 +28,17 @@ class DispatchWebhooks
     protected $jobClass;
 
     /**
-     * The action to handle the job.
-     *
-     * @var callable
-     */
-    protected $actionClass;
-
-    /**
      * Setup.
      *
-     * @param IShopQuery $shopQuery   The querier for the shop.
-     * @param string     $jobClass    The job to dispatch.
-     * @param callable   $actionClass The action to handle the job.
+     * @param IShopQuery $shopQuery The querier for the shop.
+     * @param string     $jobClass  The job to dispatch.
      *
      * @return void
      */
-    public function __construct(IShopQuery $shopQuery, string $jobClass, callable $actionClass)
+    public function __construct(IShopQuery $shopQuery, string $jobClass)
     {
         $this->shopQuery = $shopQuery;
         $this->jobClass = $jobClass;
-        $this->actionClass = $actionClass;
     }
 
     /**
@@ -74,13 +65,11 @@ class DispatchWebhooks
         if ($inline) {
             ($this->jobClass)::dispatchNow(
                 $shop->getId(),
-                $this->actionClass,
                 $webhooks
             );
         } else {
             ($this->jobClass)::dispatch(
                 $shop->getId(),
-                $this->actionClass,
                 $webhooks
             )->onQueue($this->getConfig('job_queues')['webhooks']);
         }

--- a/src/ShopifyApp/Messaging/Jobs/ScripttagInstaller.php
+++ b/src/ShopifyApp/Messaging/Jobs/ScripttagInstaller.php
@@ -3,11 +3,12 @@
 namespace Osiset\ShopifyApp\Messaging\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Actions\CreateScripts as CreateScriptsAction;
 
 /**
  * Webhook job responsible for handling installing scripttag.
@@ -27,13 +28,6 @@ class ScripttagInstaller implements ShouldQueue
     protected $shopId;
 
     /**
-     * Action for creating scripttags.
-     *
-     * @var string
-     */
-    protected $createScriptsAction;
-
-    /**
      * The scripts to add.
      *
      * @var array
@@ -43,28 +37,28 @@ class ScripttagInstaller implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param ShopId $shopId              The shop ID.
-     * @param string $createScriptsAction Action for creating scripttags.
-     * @param array  $configScripts       The scripts to add.
+     * @param ShopId $shopId        The shop ID.
+     * @param array  $configScripts The scripts to add.
      *
      * @return void
      */
-    public function __construct(ShopId $shopId, callable $createScriptsAction, array $configScripts)
+    public function __construct(ShopId $shopId, array $configScripts)
     {
         $this->shopId = $shopId;
-        $this->createScriptsAction = $createScriptsAction;
         $this->configScripts = $configScripts;
     }
 
     /**
      * Execute the job.
      *
+     * @param CreateScriptsAction $createScriptsAction The action for creating scripttags.
+     *
      * @return array
      */
-    public function handle(): array
+    public function handle(CreateScriptsAction $createScriptsAction): array
     {
         return call_user_func(
-            $this->createScriptsAction,
+            $createScriptsAction,
             $this->shopId,
             $this->configScripts
         );

--- a/src/ShopifyApp/Messaging/Jobs/ScripttagInstaller.php
+++ b/src/ShopifyApp/Messaging/Jobs/ScripttagInstaller.php
@@ -3,12 +3,12 @@
 namespace Osiset\ShopifyApp\Messaging\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Osiset\ShopifyApp\Actions\CreateScripts as CreateScriptsAction;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
 
 /**
  * Webhook job responsible for handling installing scripttag.

--- a/src/ShopifyApp/Messaging/Jobs/WebhookInstaller.php
+++ b/src/ShopifyApp/Messaging/Jobs/WebhookInstaller.php
@@ -3,11 +3,12 @@
 namespace Osiset\ShopifyApp\Messaging\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Actions\CreateWebhooks as CreateWebhooksAction;
 
 /**
  * Webhook job responsible for handling installation of webhook listeners.
@@ -18,19 +19,13 @@ class WebhookInstaller implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+
     /**
      * The shop's ID.
      *
      * @var int
      */
     protected $shopId;
-
-    /**
-     * Action for creating webhooks.
-     *
-     * @var callable
-     */
-    protected $createWebhooksAction;
 
     /**
      * The webhooks to add.
@@ -42,28 +37,28 @@ class WebhookInstaller implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param ShopId $shopId               The shop ID.
-     * @param string $createWebhooksAction Action for creating webhooks.
-     * @param array  $configWebhooks       The webhooks to add.
+     * @param ShopId $shopId         The shop ID.
+     * @param array  $configWebhooks The webhooks to add.
      *
      * @return void
      */
-    public function __construct(ShopId $shopId, callable $createWebhooksAction, array $configWebhooks)
+    public function __construct(ShopId $shopId, array $configWebhooks)
     {
         $this->shopId = $shopId;
-        $this->createWebhooksAction = $createWebhooksAction;
         $this->configWebhooks = $configWebhooks;
     }
 
     /**
      * Execute the job.
      *
+     * @param CreateWebhooksAction $createWebhooksAction The action for creating webhooks.
+     *
      * @return array
      */
-    public function handle(): array
+    public function handle(CreateWebhooksAction $createWebhooksAction): array
     {
         return call_user_func(
-            $this->createWebhooksAction,
+            $createWebhooksAction,
             $this->shopId,
             $this->configWebhooks
         );

--- a/src/ShopifyApp/Messaging/Jobs/WebhookInstaller.php
+++ b/src/ShopifyApp/Messaging/Jobs/WebhookInstaller.php
@@ -3,12 +3,12 @@
 namespace Osiset\ShopifyApp\Messaging\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Osiset\ShopifyApp\Actions\CreateWebhooks as CreateWebhooksAction;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
 
 /**
  * Webhook job responsible for handling installation of webhook listeners.

--- a/src/ShopifyApp/ShopifyAppProvider.php
+++ b/src/ShopifyApp/ShopifyAppProvider.php
@@ -163,15 +163,13 @@ class ShopifyAppProvider extends ServiceProvider
             DispatchWebhooksAction::class => [self::CBIND, function ($app) {
                 return new DispatchWebhooksAction(
                     $app->make(IShopQuery::class),
-                    WebhookInstaller::class,
-                    $app->make(CreateWebhooksAction::class)
+                    WebhookInstaller::class
                 );
             }],
             DispatchScriptsAction::class => [self::CBIND, function ($app) {
                 return new DispatchScriptsAction(
                     $app->make(IShopQuery::class),
-                    ScripttagInstaller::class,
-                    $app->make(CreateScriptsAction::class)
+                    ScripttagInstaller::class
                 );
             }],
             AfterAuthorizeAction::class => [self::CBIND, function ($app) {


### PR DESCRIPTION
Issue seems to not be present until latest version of Laravel. Job action class passed into dispatch scripts and dispatch webhooks jobs fails because it tries to serialize the class.

Modified flow to use `handle` to resolve the class needed.