### PR TITLE
Fix make webhook stub

### DIFF
--- a/src/ShopifyApp/Console/stubs/webhook-job.stub
+++ b/src/ShopifyApp/Console/stubs/webhook-job.stub
@@ -6,7 +6,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 
 class DummyClass implements ShouldQueue
 {


### PR DESCRIPTION
Currently webhook stub use interface:
`use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain;`

So this code produce error:
`public function handle()
{
    // Convert domain
    $this->shopDomain = ShopDomain::fromNative($this->domain);

    // Do what you wish with the data
    // Access domain name as $this->shopDomain->toNative()
}`

Right one use statement `use Osiset\ShopifyApp\Objects\Values\ShopDomain;`