### PR TITLE
Fix high usage of memory during installation

### DIFF
--- a/src/ShopifyApp/Storage/Queries/Shop.php
+++ b/src/ShopifyApp/Storage/Queries/Shop.php
@@ -42,7 +42,6 @@ class Shop implements IShopQuery
         }
 
         return $result
-            ->get()
             ->where('id', $shopId->toNative())
             ->first();
     }
@@ -58,7 +57,6 @@ class Shop implements IShopQuery
         }
 
         return $result
-            ->get()
             ->where('name', $domain->toNative())
             ->first();
     }


### PR DESCRIPTION
Fix high usage of memory during installation occurs when users table has a lot of users.