### PR TITLE
Use `contains()` to support route prefixes

### DIFF
--- a/src/ShopifyApp/Http/Middleware/VerifyShopify.php
+++ b/src/ShopifyApp/Http/Middleware/VerifyShopify.php
@@ -106,7 +106,7 @@ class VerifyShopify
         }
 
         // Continue if current route is an auth or billing route
-        if (Str::startsWith($request->getRequestUri(), ['/authenticate', '/billing'])) {
+        if (Str::contains($request->getRequestUri(), ['/authenticate', '/billing'])) {
             return $next($request);
         }
 


### PR DESCRIPTION
When using a route prefix, `Str::startsWith($request->getRequestUri(), ['/authenticate', '/billing'])` isn't going to match the route URL. I changed it to `Str::contains()` so that it can be anywhere in the URL.

Case in point - my routes:

![Screen Shot 2021-05-05 at 12 20 01 PM](https://user-images.githubusercontent.com/748444/117191292-a1259e80-ad9d-11eb-9cb8-befb6263400a.png)

This can still potentially cause problems if the "authenticate" or "billing" routes are manually registered and _don't_ contain `/authenticate` or `/billing`. However, IMO that's a pretty big edge case that I don't think needs to be accounted for at this point.