### PR TITLE
Check for "?" in URLs instead of "&" when determining the separator

### DIFF
--- a/src/ShopifyApp/helpers.php
+++ b/src/ShopifyApp/helpers.php
@@ -206,7 +206,7 @@ function tokenUrl(string $url, ?ShopModel $shop = null): string
     }
 
     // Determine the seperator and get the token from the shop
-    $sep = Str::contains($url, '&') ? '&' : '?';
+    $sep = Str::contains($url, '?') ? '&' : '?';
     $token = $shop->getSessionContext()->getSessionToken()->toNative();
 
     return "{$url}{$sep}token={$token}";

--- a/src/ShopifyApp/resources/views/auth/token.blade.php
+++ b/src/ShopifyApp/resources/views/auth/token.blade.php
@@ -38,7 +38,7 @@
     @if(config('shopify-app.appbridge_enabled'))
         <script>
             utils.getSessionToken(app).then((token) => {
-                window.location.href = `{!! $target !!}{!! Str::contains($target, '&') ? '&' : '?' !!}token=${token}`;
+                window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}token=${token}`;
             });
         </script>
     @endif


### PR DESCRIPTION
It was checking for "&" in the URLs when deciding whether to add "&" or "?", but it should check for "?" instead.

For example: `foo.bar/baz?blah` doesn't contain a "&" so it would append a "?" and return `foo.bar/baz?blah?token=...`