### PR TITLE
Remove "token" from the query string of the target URL

### DIFF
--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -72,11 +72,7 @@ trait AuthController
             $params = parseQueryString($query);
             unset($params['token']);
 
-            $cleanTarget = trim(str_replace(
-                '?' . $query,
-                '?' . http_build_query($params),
-                $target
-            ), '?');
+            $cleanTarget = trim(explode('?', $target)[0] . '?' . http_build_query($params), '?');
         } else {
             $cleanTarget = $target;
         }


### PR DESCRIPTION
If the `target` URL already has a `token` query param then it ends up doubling up in the subsequent request:

![Screen Shot 2021-05-06 at 4 56 53 PM](https://user-images.githubusercontent.com/748444/117376092-abbf6100-ae8d-11eb-9b94-451853651b43.png)

![Screen Shot 2021-05-06 at 4 57 02 PM](https://user-images.githubusercontent.com/748444/117376115-b37f0580-ae8d-11eb-9743-69c4f793d693.png)

This PR removes "token" from the query params before passing it to the view