### PR TITLE
Feature/cookieless - changes for turbolinks, install app 

### DIFF
--- a/src/ShopifyApp/Http/Middleware/VerifyShopify.php
+++ b/src/ShopifyApp/Http/Middleware/VerifyShopify.php
@@ -417,7 +417,7 @@ class VerifyShopify
     {
         if (getShopifyConfig('turbo_enabled')) {
             if ($request->bearerToken()) {
-                // Bearer tokens collect. 
+                // Bearer tokens collect.
                 // Since Turbo does not refresh the page, the method is called several times in a row, values are attached to the same header.
                 $bearerTokens = Collection::make(explode(',', $request->header('Authorization', '')));
                 $newestToken = Str::substr(trim($bearerTokens->last()), 7);
@@ -548,6 +548,8 @@ class VerifyShopify
      */
     protected function checkPreviousInstallation(Request $request): bool
     {
-        return (bool) $this->shopQuery->getByDomain($this->getShopDomainFromRequest($request), [], true);
+        $shop = $this->shopQuery->getByDomain($this->getShopDomainFromRequest($request), [], true);
+
+        return ($shop && !$shop->trashed());
     }
 }

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -26,7 +26,13 @@ trait AuthController
     public function authenticate(Request $request, AuthenticateShop $authShop)
     {
         // Get the shop domain
-        $shopDomain = ShopDomain::fromNative($request->get('shop'));
+        if (getShopifyConfig('turbo_enabled')) {
+            // If the user clicked on any link before load Turbo and receiving the token
+            $shopDomain = $request->user()->getDomain();
+            $request['shop'] = $shopDomain->toNative();
+        } else {
+            $shopDomain = ShopDomain::fromNative($request->get('shop'));
+        }
 
         // Run the action
         [$result, $status] = $authShop($request);

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -26,7 +26,7 @@ trait AuthController
     public function authenticate(Request $request, AuthenticateShop $authShop)
     {
         // Get the shop domain
-        if (getShopifyConfig('turbo_enabled')) {
+        if (getShopifyConfig('turbo_enabled') && $request->user()) {
             // If the user clicked on any link before load Turbo and receiving the token
             $shopDomain = $request->user()->getDomain();
             $request['shop'] = $shopDomain->toNative();

--- a/src/ShopifyApp/resources/views/layouts/default.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/default.blade.php
@@ -20,20 +20,24 @@
         @if(\Osiset\ShopifyApp\getShopifyConfig('appbridge_enabled'))
             <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
-            <script>
-                AppBridge = window['app-bridge'];
-                actions = AppBridge.actions;
-                utils = window['app-bridge-utils'];
-                createApp = AppBridge.default;
-                app = createApp({
+            <script
+                @if(\Osiset\ShopifyApp\getShopifyConfig('turbo_enabled'))
+                    data-turbolinks-eval="false"
+                @endif
+            >
+                const AppBridge = window['app-bridge'];
+                const actions = AppBridge.actions;
+                const utils = window['app-bridge-utils'];
+                const createApp = AppBridge.default;
+                const app = createApp({
                     apiKey: "{{ \Osiset\ShopifyApp\getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
                     shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
                     forceRedirect: true,
                 });
             </script>
             @if(\Osiset\ShopifyApp\getShopifyConfig('turbo_enabled'))
-                <script>
-                    SESSION_TOKEN_REFRESH_INTERVAL = 2000;
+                <script data-turbolinks-eval="false">
+                    const SESSION_TOKEN_REFRESH_INTERVAL = 2000;
 
                     // Token updates
                     document.addEventListener("turbolinks:load", (event) => {

--- a/src/ShopifyApp/resources/views/layouts/default.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/default.blade.php
@@ -21,28 +21,43 @@
             <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script>
-                const AppBridge = window['app-bridge'];
-                const actions = AppBridge.actions;
-                const utils = window['app-bridge-utils'];
-                const createApp = AppBridge.default;
-                const app = createApp({
+                AppBridge = window['app-bridge'];
+                actions = AppBridge.actions;
+                utils = window['app-bridge-utils'];
+                createApp = AppBridge.default;
+                app = createApp({
                     apiKey: "{{ \Osiset\ShopifyApp\getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
                     shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
                     forceRedirect: true,
                 });
             </script>
             @if(\Osiset\ShopifyApp\getShopifyConfig('turbo_enabled'))
-            <script>
-                document.addEventListener("turbolinks:request-start", (event) => {
-                    utils.getSessionToken(app).then((token) => {
-                        let xhr = event.data.xhr;
-                        xhr.open('GET', event.data.url, true);
-                        xhr.setRequestHeader("Authorization", "Bearer " + token);
-                        xhr.send();
-                    });
-                });
+                <script>
+                    SESSION_TOKEN_REFRESH_INTERVAL = 2000;
 
-            </script>
+                    // Token updates
+                    document.addEventListener("turbolinks:load", (event) => {
+                        retrieveToken(app);
+                        keepRetrievingToken(app);
+                    });
+
+                    // Retrieve session token
+                    async function retrieveToken(app) {
+                        window.sessionToken = await utils.getSessionToken(app);
+                    }
+
+                    // Keep retrieving a session token periodically
+                    function keepRetrievingToken(app) {
+                        setInterval(() => {
+                            retrieveToken(app);
+                        }, SESSION_TOKEN_REFRESH_INTERVAL);
+                    }
+
+                    document.addEventListener("turbolinks:request-start", (event) => {
+                        let xhr = event.data.xhr;
+                        xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+                    });
+                </script>
             @endif
 
             @include('shopify-app::partials.flash_messages')


### PR DESCRIPTION
In my case, when I tried to install the application, I was immediately redirected to /authenticate/token, which ended in an error. That's why I added a store check.

I also changed a little receiving and updating the token before sending Turbolinks request.
I also removed const from variables, because Turbo conflicts with constant variables.

Maybe it would be more correct to put them on a separate template
