### PR TITLE
Find shop domain in request when getting the token

### DIFF
--- a/src/ShopifyApp/Objects/Values/SessionToken.php
+++ b/src/ShopifyApp/Objects/Values/SessionToken.php
@@ -129,19 +129,22 @@ final class SessionToken implements SessionTokenValue
      * Contructor.
      *
      * @param string $token The JWT.
+     * @param bool $verifyToken Should the token be verified? Use false to only decode the token.
      *
-     * @return void
+     * @throws AssertionFailedException
      */
-    public function __construct(string $token)
+    public function __construct(string $token, bool $verifyToken = true)
     {
         // Confirm token formatting and decode the token
         $this->string = $token;
         $this->decodeToken();
 
-        // Confirm token signature, validity, and expiration
-        $this->verifySignature();
-        $this->verifyValidity();
-        $this->verifyExpiration();
+        if ($verifyToken) {
+            // Confirm token signature, validity, and expiration
+            $this->verifySignature();
+            $this->verifyValidity();
+            $this->verifyExpiration();
+        }
     }
 
     /**

--- a/src/ShopifyApp/Objects/Values/ShopDomain.php
+++ b/src/ShopifyApp/Objects/Values/ShopDomain.php
@@ -2,9 +2,13 @@
 
 namespace Osiset\ShopifyApp\Objects\Values;
 
+use Assert\AssertionFailedException;
 use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
+use Osiset\ShopifyApp\Exceptions\MissingShopDomainException;
 use function Osiset\ShopifyApp\getShopifyConfig;
+use function Osiset\ShopifyApp\parseQueryString;
 
 /**
  * Value object for shop's domain.
@@ -23,6 +27,72 @@ final class ShopDomain implements ShopDomainValue
     public function __construct(string $domain)
     {
         $this->string = $this->sanitizeShopDomain($domain);
+    }
+
+    /**
+     * Find the shop domain in the given request.
+     * If the request inputs contain "shop" or "shopDomain", it is returned.
+     * If the request inputs contain "token", it is decoded and checked for a shop domain.
+     * If the request has a referrer URL, the same checks are performed against the referrer URL.
+     *
+     * @param Request $request
+     *
+     * @return string
+     * @throws MissingShopDomainException
+     */
+    public static function getFromRequest(Request $request): string
+    {
+        // check the request input for the shop
+        if ($request->has('shop')) {
+            return self::fromNative($request->input('shop'))->toNative();
+        }
+
+        if ($request->has('shopDomain')) {
+            return self::fromNative($request->input('shopDomain'))->toNative();
+        }
+
+        if ($request->has('token')) {
+            try {
+                $token = new SessionToken($request->input('token'), $verifyToken = false);
+
+                if ($shopDomain = $token->getShopDomain()) {
+                    return $shopDomain->toNative();
+                }
+            } catch (AssertionFailedException $e) {
+                // unable to decode the token
+            }
+        }
+
+        // check the referrer for the shop
+        $referrer = $request->header('referer');
+
+        if (filled($referrer)) {
+            $query = parse_url($referrer, PHP_URL_QUERY);
+            $params = parseQueryString($query);
+
+            if (isset($params['shop'])) {
+                return self::fromNative($params['shop'])->toNative();
+            }
+
+            if (isset($params['shopDomain'])) {
+                return self::fromNative($params['shopDomain'])->toNative();
+            }
+
+            if (isset($params['token'])) {
+                try {
+                    $token = new SessionToken($params['token'], $verifyToken = false);
+
+                    if ($shopDomain = $token->getShopDomain()) {
+                        return $shopDomain->toNative();
+                    }
+                } catch (AssertionFailedException $e) {
+                    // unable to decode the token
+                }
+            }
+        }
+
+        // unable to determine the shop
+        throw new MissingShopDomainException('Unable to get shop domain from request');
     }
 
     /**

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -69,8 +69,9 @@ trait AuthController
      */
     public function token(Request $request)
     {
-        $target = $request->query('target');
+        $shop = ShopDomain::getFromRequest($request);
 
+        $target = $request->query('target');
         $query = parse_url($target, PHP_URL_QUERY);
 
         if ($query) {
@@ -86,7 +87,7 @@ trait AuthController
         return View::make(
             'shopify-app::auth.token',
             [
-                'shopDomain' => ShopDomain::fromNative($request->query('shop'))->toNative(),
+                'shopDomain' => ShopDomain::fromNative($shop)->toNative(),
                 'target'     => $cleanTarget,
             ]
         );

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -69,7 +69,7 @@ trait AuthController
      */
     public function token(Request $request)
     {
-        $shop = ShopDomain::getFromRequest($request);
+        $shopDomain = ShopDomain::getFromRequest($request);
 
         $target = $request->query('target');
         $query = parse_url($target, PHP_URL_QUERY);
@@ -87,7 +87,7 @@ trait AuthController
         return View::make(
             'shopify-app::auth.token',
             [
-                'shopDomain' => ShopDomain::fromNative($shop)->toNative(),
+                'shopDomain' => $shopDomain,
                 'target'     => $cleanTarget,
             ]
         );

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -87,7 +87,7 @@ trait AuthController
         return View::make(
             'shopify-app::auth.token',
             [
-                'shopDomain' => $shopDomain,
+                'shopDomain' => $shopDomain->toNative(),
                 'target'     => $cleanTarget,
             ]
         );


### PR DESCRIPTION
When redirecting within your app, it's easy to get into a state where there isn't a "shop" query param for the token controller to use. At that point you're completely stuck because you can't auth anymore. You're at the end of the road.

This PR adds a static method `ShopDomain::getFromRequest()` that tries to find the token in the request in multiple ways:

1. If the request inputs contain "shop" or "shopDomain", it is used.
2. If the request headers contain "X-Shop-Domain", it is used.
3. If the request headers have a referrer URL then the same checks are performed against it ("shop" and "shopDomain")
4. If the referrer URL contains a "token" query param, it is decoded and checked for a shop domain.
    - To accomplish this, I added an optional param to the `SessionToken` constructor that allows us to *not* verify the token. This allows us to decode it and get the values regardless of its validity/expiration. It defaults to verifying the token, which is the original functionality.

The end result is that in most cases, the token controller is able to find the shop and you can continue forward as expected.