### PR TITLE
Always pass the filtered query params to the token redirect

### DIFF
--- a/src/ShopifyApp/Http/Middleware/VerifyShopify.php
+++ b/src/ShopifyApp/Http/Middleware/VerifyShopify.php
@@ -279,9 +279,10 @@ class VerifyShopify
     {
         // At this point the HMAC and other details are verified already, filter it out
         $path = $request->path();
-        $target = Str::startsWith($path, '/') ? $path : "/{$path}";
-        if ($request->has('hmac')) {
-            $filteredQuery = Collection::make($request->all())->except([
+        $target = Str::start($path, '/');
+
+        if ($request->query()) {
+            $filteredQuery = Collection::make($request->query())->except([
                 'hmac',
                 'host',
                 'locale',
@@ -290,8 +291,9 @@ class VerifyShopify
                 'session',
                 'shop',
             ]);
-            if (count($filteredQuery) > 0) {
-                $target .= '?'.http_build_query($filteredQuery->toArray());
+
+            if ($filteredQuery->isNotEmpty()) {
+                $target .= '?' . http_build_query($filteredQuery->toArray());
             }
         }
 


### PR DESCRIPTION
I noticed that my routes that had query params were losing the query params when they were going through the token redirect route. The only way the query params were being passed through is if they included "hmac". This PR makes it so that query params (filtered) are always passed through to the token redirect route.

One thing to note is that I changed `$request->all()` to `$request->query()`. I couldn't think of any reason to use `all()` because that includes POST params, file keys, etc. Converting everything to query params could potentially cause some problems.