### PR TITLE
Feature/cookieless - billing for the safari browser

### DIFF
--- a/src/ShopifyApp/Traits/BillingController.php
+++ b/src/ShopifyApp/Traits/BillingController.php
@@ -10,19 +10,38 @@ use Illuminate\Support\Facades\View;
 use Osiset\ShopifyApp\Actions\ActivatePlan;
 use Osiset\ShopifyApp\Actions\ActivateUsageCharge;
 use Osiset\ShopifyApp\Actions\GetPlanUrl;
-use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+use function Osiset\ShopifyApp\getShopForBilling;
 use function Osiset\ShopifyApp\getShopifyConfig;
 use Osiset\ShopifyApp\Http\Requests\StoreUsageCharge;
 use Osiset\ShopifyApp\Objects\Transfers\UsageChargeDetails as UsageChargeDetailsTransfer;
 use Osiset\ShopifyApp\Objects\Values\ChargeReference;
 use Osiset\ShopifyApp\Objects\Values\NullablePlanId;
 use Osiset\ShopifyApp\Objects\Values\PlanId;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 
 /**
  * Responsible for billing a shop for plans and usage charges.
  */
 trait BillingController
 {
+    /**
+     * The shop querier.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
+
+    /**
+     * Constructor.
+     *
+     * @param IShopQuery     $shopQuery The shop querier.
+     *
+     * @return void
+     */
+    public function __construct(IShopQuery $shopQuery) {
+        $this->shopQuery = $shopQuery;
+    }
+
     /**
      * Redirects to billing screen for Shopify.
      *
@@ -63,16 +82,26 @@ trait BillingController
         Request $request,
         ActivatePlan $activatePlan
     ): RedirectResponse {
+
+        // Get the store and if it does not exist (in the case of safari) redirect to get the domain)
+        $shop = getShopForBilling($request);
+        if (! $shop) {
+            return Redirect::route(getShopifyConfig('route_names.billing.token'), [
+                'target' => url()->current(),
+                'charge_id' => $request->query('charge_id')
+            ]);
+        }
+
         // Activate the plan and save
         $result = $activatePlan(
-            $request->user()->getId(),
+            $shop->getId(),
             PlanId::fromNative($plan),
             ChargeReference::fromNative((int) $request->query('charge_id'))
         );
 
         // Go to homepage of app
         return Redirect::route(getShopifyConfig('route_names.home'), [
-            'shop' => $request->user()->getDomain()->toNative(),
+            'shop' => $shop->getDomain()->toNative(),
         ])->with(
             $result ? 'success' : 'failure',
             'billing'
@@ -103,5 +132,21 @@ trait BillingController
         return isset($validated['redirect'])
             ? Redirect::to($validated['redirect'])->with('success', 'usage_charge')
             : Redirect::back()->with('success', 'usage_charge');
+    }
+
+    /**
+     * Redirect to the "billing domain" page in order to pick up the current domain name of the store.
+     * Only used in Safari 13 / 14 browsers.
+     *
+     * @param Request      $request      The HTTP request object.
+     *
+     * @return ViewView
+     */
+    public function processDomain(Request $request): ViewView {
+        return View::make('shopify-app::auth.billing', [
+            'target' => $request->query('target'),
+            'charge_id' => $request->query('charge_id')
+        ]);
+
     }
 }

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -57,6 +57,7 @@ return [
         'billing'              => env('SHOPIFY_ROUTE_NAME_BILLING', 'billing'),
         'billing.process'      => env('SHOPIFY_ROUTE_NAME_BILLING_PROCESS', 'billing.process'),
         'billing.usage_charge' => env('SHOPIFY_ROUTE_NAME_BILLING_USAGE_CHARGE', 'billing.usage_charge'),
+        'billing.domain'        => env('SHOPIFY_ROUTE_NAME_BILLING_DOMAIN', 'billing.domain'),
         'webhook'              => env('SHOPIFY_ROUTE_NAME_WEBHOOK', 'webhook'),
     ],
 

--- a/src/ShopifyApp/resources/routes/shopify.php
+++ b/src/ShopifyApp/resources/routes/shopify.php
@@ -135,4 +135,13 @@ Route::group(['prefix' => getShopifyConfig('prefix'), 'middleware' => ['web']], 
         ->middleware(['verify.shopify'])
         ->name(getShopifyConfig('route_names.billing.usage_charge'));
     }
+
+    if (registerPackageRoute('billing.domain', $manualRoutes)) {
+        Route::get(
+            '/billing/domain',
+            'Osiset\ShopifyApp\Http\Controllers\BillingController@processDomain'
+        )
+        ->middleware(['verify.shopify'])
+        ->name(getShopifyConfig('route_names.billing.domain'));
+    }
 });

--- a/src/ShopifyApp/resources/views/auth/billing.blade.php
+++ b/src/ShopifyApp/resources/views/auth/billing.blade.php
@@ -1,0 +1,34 @@
+
+@include('shopify-app::partials.polaris_skeleton_css')
+
+<div>
+    <div class="Polaris-SkeletonPage__Page" role="status" aria-label="Page loading">
+        <div class="Polaris-SkeletonPage__Header">
+            <div class="Polaris-SkeletonPage__TitleAndPrimaryAction">
+                <div class="Polaris-SkeletonPage__TitleWrapper">
+                    <div class="Polaris-SkeletonPage__SkeletonTitle"></div>
+                </div>
+            </div>
+        </div>
+        <div class="Polaris-SkeletonPage__Content">
+            <div class="Polaris-Layout">
+                <div class="Polaris-Layout__Section">
+                    <div class="Polaris-Card">
+                        <div class="Polaris-Card__Section">
+                            <div class="Polaris-SkeletonBodyText__SkeletonBodyTextContainer">
+                            <div class="Polaris-SkeletonBodyText"></div>
+                            <div class="Polaris-SkeletonBodyText"></div>
+                            <div class="Polaris-SkeletonBodyText"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let paramsString = `shop=${sessionStorage.shopify_domain}&charge_id={{$charge_id}}`;
+        window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}${paramsString}`;
+    </script>
+</div>
+

--- a/src/ShopifyApp/resources/views/layouts/default.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/default.blade.php
@@ -35,6 +35,18 @@
                     forceRedirect: true,
                 });
             </script>
+            <script
+                @if(\Osiset\ShopifyApp\getShopifyConfig('turbo_enabled'))
+                    data-turbolinks-eval="false"
+                @endif
+            >
+                const userAgent = navigator.userAgent.toLowerCase();
+                const isSafari = /safari/.test(userAgent);
+
+                if (isSafari) {
+                    sessionStorage.shopify_domain = "{{ $shopDomain ?? Auth::user()->name }}";
+                }
+            </script>
             @if(\Osiset\ShopifyApp\getShopifyConfig('turbo_enabled'))
                 <script data-turbolinks-eval="false">
                     const SESSION_TOKEN_REFRESH_INTERVAL = 2000;


### PR DESCRIPTION
At the moment, when I try to change my plan on safari, I get an error. The error is because Safari doesn't remember the session, unlike firefox or chrome. (BillingController@index auth()->user() returns null).

Also, the problem was that only "charge_id" comes in "request" after returning from shopify.
$request->user() is also not available.

So I add for safari browser to sessionStorage (localStorage is also not saved in safari) the current domain and when billing I take it from there. (For all other browsers logic remains the same).
_________
"usageCharge" I didn't change as I don't use them.
