### PR TITLE
fix the bugs to redirect to login page if auth empty

### DIFF
--- a/src/ShopifyApp/Http/Middleware/AuthShopify.php
+++ b/src/ShopifyApp/Http/Middleware/AuthShopify.php
@@ -352,8 +352,8 @@ class AuthShopify
     private function handleBadVerification(Request $request, ShopDomainValue $domain)
     {
         if ($domain->isNull()) {
-            // We have no idea of knowing who this is, this should not happen
-            throw new MissingShopDomainException();
+            //Rediect to login page if auth domain empty
+            return redirect()->route('login'); // 
         }
 
         // Set the return-to path so we can redirect after successful authentication


### PR DESCRIPTION
Problem:
on localhost, geting error "Osiset\ShopifyApp\Exceptions\MissingShopDomainException".  

Solution 
here I have redirected to login page if shop parameter auth domain empty the login page will display, there user/developer can add their shop url to continue the installation of app.

also, I have added login.blade.php and route entry example code with steps in the installtion wiki guide