### PR TITLE
Retain host parameter

### DIFF
--- a/src/ShopifyApp/Http/Middleware/VerifyShopify.php
+++ b/src/ShopifyApp/Http/Middleware/VerifyShopify.php
@@ -270,7 +270,6 @@ class VerifyShopify
         if ($request->query()) {
             $filteredQuery = Collection::make($request->query())->except([
                 'hmac',
-                'host',
                 'locale',
                 'new_design_language',
                 'timestamp',


### PR DESCRIPTION
Hoping I haven't done unintended here. I'm sure someone will tell me if I have. 

Removed host parameter from filter. AppBridge 2 requires this parameter to be set in initialisation, so having it on the url is very useful.

I bumped to 2.0.3 for this: 

`package.json`

    "dependencies": {
        "@shopify/app-bridge": "^2.0.3",
        "@shopify/app-bridge-react": "^2.0.3",
        "@shopify/app-bridge-utils": "^2.0.3"
    ...

As the host parameter is now available on the url, it could be placed on the blade template for my SPA

    <input type="hidden" id="host" value="{{ \Request::get('host') }}" />

And included by my top js.

    ...
    const config = {
        host: document.getElementById("host").value,
        ...
    }