### PR TITLE
Do not use env() helper outside the config file.

### DIFF
--- a/tests/Traits/HomeControllerTest.php
+++ b/tests/Traits/HomeControllerTest.php
@@ -2,9 +2,9 @@
 
 namespace Osiset\ShopifyApp\Test\Traits;
 
+use function Osiset\ShopifyApp\getShopifyConfig;
 use Osiset\ShopifyApp\Services\ShopSession;
 use Osiset\ShopifyApp\Test\TestCase;
-use function Osiset\ShopifyApp\getShopifyConfig;
 
 class HomeControllerTest extends TestCase
 {

--- a/tests/Traits/HomeControllerTest.php
+++ b/tests/Traits/HomeControllerTest.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Test\Traits;
 
 use Osiset\ShopifyApp\Services\ShopSession;
 use Osiset\ShopifyApp\Test\TestCase;
+use function Osiset\ShopifyApp\getShopifyConfig;
 
 class HomeControllerTest extends TestCase
 {
@@ -26,7 +27,7 @@ class HomeControllerTest extends TestCase
 
         $this->call('get', '/', [], ['itp' => true])
             ->assertOk()
-            ->assertSee("apiKey: '".env('SHOPIFY_API_KEY')."'", false)
+            ->assertSee("apiKey: '".getShopifyConfig('api_key')."'", false)
             ->assertSee("shopOrigin: '{$shop->name}'", false);
     }
 


### PR DESCRIPTION
Do not use `env()` helper outside the config file.