### PR TITLE
Add backward compatibility with REST-style webhook topics (e.g. "orders/create")

### DIFF
--- a/src/ShopifyApp/Console/WebhookJobMakeCommand.php
+++ b/src/ShopifyApp/Console/WebhookJobMakeCommand.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Console;
 
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Util;
 use Symfony\Component\Console\Input\InputArgument;
 
 class WebhookJobMakeCommand extends JobMakeCommand
@@ -54,13 +55,18 @@ class WebhookJobMakeCommand extends JobMakeCommand
     {
         $result = parent::handle();
 
+        $topic = Util::getGraphQLWebhookTopic($this->argument('topic'));
+
+        $type = $this->getUrlFromName($this->argument('name'));
+        $address = route(Util::getShopifyConfig('route_names.webhook'), $type);
+
         // Remind user to enter job into config
         $this->info("For non-GDPR webhooks, don't forget to register the webhook in config/shopify-app.php. Example:");
         $this->info("
     'webhooks' => [
         [
-            'topic' => '{$this->argument('topic')}',
-            'address' => 'https://your-domain.com/webhook/{$this->getUrlFromName(trim($this->argument('name')))}'
+            'topic' => '$topic',
+            'address' => '$address'
         ]
     ]
         ");
@@ -75,13 +81,7 @@ class WebhookJobMakeCommand extends JobMakeCommand
      */
     protected function getNameInput(): string
     {
-        $name = parent::getNameInput();
-        $suffix = 'Job';
-        if (! Str::endsWith($name, $suffix)) {
-            $name .= $suffix;
-        }
-
-        return $name;
+        return Str::finish(parent::getNameInput(), 'Job');
     }
 
     /**
@@ -93,10 +93,10 @@ class WebhookJobMakeCommand extends JobMakeCommand
      */
     protected function getUrlFromName(string $name): string
     {
-        if (Str::endsWith($name, 'Job')) {
-            $name = substr($name, 0, -3);
-        }
-
-        return strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $name));
+        return Str::of($name)
+                  ->trim()
+                  ->beforeLast('Job')
+                  ->replaceMatches('/(?<!^)[A-Z]/', '-$0')
+                  ->lower();
     }
 }

--- a/src/ShopifyApp/Console/WebhookJobMakeCommand.php
+++ b/src/ShopifyApp/Console/WebhookJobMakeCommand.php
@@ -95,7 +95,7 @@ class WebhookJobMakeCommand extends JobMakeCommand
     {
         return Str::of($name)
                   ->trim()
-                  ->beforeLast('Job')
+                  ->replaceMatches('/Job$/', '')
                   ->replaceMatches('/(?<!^)[A-Z]/', '-$0')
                   ->lower();
     }

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -384,8 +384,12 @@ class ApiHelper implements IApiHelper
         }
         ';
 
+        // change REST-format topics ("resource/event")
+        // to GraphQL-format topics ("RESOURCE_EVENT") for pre-v17 compatibility
+        $topic = Util::getGraphQLWebhookTopic($payload['topic']);
+
         $variables = [
-            'topic'               => $payload['topic'],
+            'topic'               => $topic,
             'webhookSubscription' => [
                 'callbackUrl' => $payload['address'],
                 'format'      => 'JSON',

--- a/src/ShopifyApp/Util.php
+++ b/src/ShopifyApp/Util.php
@@ -194,4 +194,19 @@ class Util
 
         return Arr::get($config, $key);
     }
+
+    /**
+     * Convert a REST-format webhook topic ("resource/event")
+     * to a GraphQL-format webhook topic ("RESOURCE_EVENT").
+     *
+     * @param string $topic
+     *
+     * @return string
+     */
+    public static function getGraphQLWebhookTopic(string $topic): string
+    {
+        return Str::of($topic)
+                  ->upper()
+                  ->replaceMatches('/[^A-Z_]/', '_');
+    }
 }

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -310,8 +310,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option is for defining webhooks.
-    | Key is for the Shopify webhook event
-    | Value is for the endpoint to call
+    | `topic` is the GraphQL value of the Shopify webhook event.
+    | `address` is the endpoint to call.
+    |
+    | Valid values for `topic` can be found here:
+    | https://shopify.dev/api/admin/graphql/reference/events/webhooksubscriptiontopic
     |
     */
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -82,4 +82,27 @@ class UtilTest extends TestCase
         $this->assertEquals('hello world', $secret);
         $this->assertEquals('OFFLINE', $grantMode);
     }
+
+    public function testGraphQLWebhookTopic(): void
+    {
+        // REST-format topics are changed to the GraphQL format
+        $topics = [
+            'app/uninstalled' => 'APP_UNINSTALLED',
+            'orders/partially_fulfilled' => 'ORDERS_PARTIALLY_FULFILLED',
+            'order_transactions/create' => 'ORDER_TRANSACTIONS_CREATE',
+        ];
+
+        foreach ($topics as $restTopic => $graphQLTopic) {
+            $this->assertEquals(
+                $graphQLTopic,
+                Util::getGraphQLWebhookTopic($restTopic)
+            );
+        }
+
+        // GraphQL-format topics are unchanged
+        $this->assertEquals(
+            'ORDERS_PARTIALLY_FULFILLED',
+            Util::getGraphQLWebhookTopic('ORDERS_PARTIALLY_FULFILLED')
+        );
+    }
 }


### PR DESCRIPTION
v17 requires webhooks to be configured with GraphQL-style webhook topics (e.g. "ORDERS_CREATE") instead of the previously-used REST-style webhook topics (e.g. "orders/create"). If there are webhooks in the config and `topic` isn't changed on all of them during the upgrade process, an exception is thrown that it isn't terribly clear how to fix: `Variable $topic of type WebhookSubscriptionTopic! was provided invalid value`.

This PR adds backward compatibility with REST-style webhook topics through the use of a new utility method: `Util::getGraphQLWebhookTopic(string $topic): string`

```php
Util::getGraphQLWebhookTopic('orders/created') === 'ORDERS_CREATED'
```

When the webhooks in the config are being created on the store, the `topic` is run through this method to ensure that the GraphQL-style topic is being used, even if the topic in the config is REST style.

---

I also updated the `shopify-app:make:webhook` command output to include the GraphQL-style topic and the actual webhook handler URL (instead of a generic URL). For example:

```
$ php artisan shopify-app:make:webhook OrdersCreate orders/create
For non-GDPR webhooks, don't forget to register the webhook in config/shopify-app.php. Example:

    'webhooks' => [
        [
            'topic' => 'ORDERS_CREATE',
            'address' => 'https://shopifyapptest.ngrok.io/webhook/orders-create'
        ]
    ]
```