### PR TITLE
Increase default Shopify API version from `2020-01` to `2021-01`

### DIFF
--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -139,7 +139,7 @@ return [
     | This option is for the app's API version string.
     | Use "YYYY-MM" or "unstable". Refer to Shopify's documentation
     | at https://shopify.dev/api/usage/versioning#release-schedule
-    | on API versioning for the current stable version.
+    | for the current stable version.
     |
     */
 

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -138,11 +138,12 @@ return [
     |
     | This option is for the app's API version string.
     | Use "YYYY-MM" or "unstable". Refer to Shopify's documentation
+    | at https://shopify.dev/api/usage/versioning#release-schedule
     | on API versioning for the current stable version.
     |
     */
 
-    'api_version' => env('SHOPIFY_API_VERSION', '2020-01'),
+    'api_version' => env('SHOPIFY_API_VERSION', '2021-01'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -42,7 +42,7 @@ class ApiHelperTest extends TestCase
         $this->assertInstanceOf(BasicShopifyAPI::class, $api);
         $this->assertSame(Util::getShopifyConfig('api_secret'), $this->app['config']->get('shopify-app.api_secret'));
         $this->assertSame(Util::getShopifyConfig('api_key'), $this->app['config']->get('shopify-app.api_key'));
-        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2020-01');
+        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2021-01');
     }
 
     public function testSetAndGetApi(): void


### PR DESCRIPTION
If you don't specify a Shopify API version in `.env` then it defaults to `2020-01`, which hasn't been supported since January 1, 2021. I increased the default to `2021-01`, which is supported until January 1, 2022 (~5 months). I also added a link to Shopify's versioning docs.