### PR TITLE
Enable PHP-CS-Fixer in Github Action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 .editorconfig            export-ignore
 .gitattributes           export-ignore
 .gitignore               export-ignore
-.styleci.yml             export-ignore
+.php-cs-fixer.dist.php   export-ignore
 CODE_OF_CONDUCT.md       export-ignore
 phpunit.xml              export-ignore
 CONTRIBUTING.md          export-ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: PHP Lint
+
+on: [ push, pull_request ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      - name: Check for code style violation with PHP-CS-Fixer
+        uses: OskarStark/php-cs-fixer-ga@3.0.0
+        with:
+          args: --diff --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /build
 /vendor
 composer.lock
+.php-cs-fixer.cache
 .phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,63 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$rules = [
+    '@PSR2' => true,
+    '@PSR12' => true,
+    'array_syntax' => [
+        'syntax' => 'short',
+    ],
+    'binary_operator_spaces' => true,
+    'blank_line_after_namespace' => true,
+    'blank_line_before_statement' => true,
+    'cast_spaces' => true,
+    'concat_space' => [
+        'spacing' => 'none',
+    ],
+    'ereg_to_preg' => true,
+    'is_null' => true,
+    'line_ending' => true,
+    'modernize_types_casting' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_short_bool_cast' => true,
+    'no_unneeded_control_parentheses' => true,
+    'no_unused_imports' => true,
+    'no_whitespace_in_blank_line' => true,
+    'ordered_imports' => true,
+    'phpdoc_align' => false,
+    'phpdoc_indent' => true,
+    'phpdoc_inline_tag_normalizer' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_no_package' => true,
+    'phpdoc_order' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_separation' => true,
+    'phpdoc_to_comment' => true,
+    'phpdoc_trim' => true,
+    'phpdoc_types' => true,
+    'phpdoc_var_without_name' => true,
+    'self_accessor' => true,
+    'single_quote' => true,
+    'space_after_semicolon' => true,
+    'standardize_not_equals' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => true,
+    'trim_array_spaces' => true,
+    'yoda_style' => [
+        'always_move_variable' => false,
+        'equal' => false,
+        'identical' => false,
+    ],
+];
+
+$finder = Finder::create()->in(__DIR__)
+    ->notPath([
+        'src/ShopifyApp/resources/config/shopify-app.php',
+    ]);
+
+return (new Config())
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setRiskyAllowed(true);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,0 @@
-preset: laravel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Its best to:
 1. Fork the repository (see adding upstream below)
 2. Create a branch such as `cool-new-feature`
 3. Create your code
-4. Create and run successfull tests (see testing below)
+4. Create and run successful tests (see testing below)
 5. Submit a pull request
 
 ## Found a bug?
@@ -38,7 +38,7 @@ Its best to:
 1. Fork the repository (see adding upstream below)
 2. Create a branch such as `issue-(issuenumber)-fix`
 3. Create your code
-4. Create and run successfull tests (see testing below)
+4. Create and run successful tests (see testing below)
 5. Submit a pull request
 6. Comment on the issue
 
@@ -58,11 +58,17 @@ You can then update by simply running:
 
 #### Locally
 
-We use PHPUnit to run tests. Simply run `composer install` and a symlink `phpunit` should be located in the `bin` directory.
+We use PHPUnit to run tests. Simply run `composer install`.
 
-Next, run `bin/phpunit` and the rest will be taken care of. Upon any pull requests and merges, TravisCI will check the code to ensure all test suites pass.
+Next, run `vendor/bin/phpunit` and the rest will be taken care of. Upon any pull requests and merges.
 
-For quicker tests, be sure to disable coverage with `bin/php --no-coverage`.
+For quicker tests, be sure to disable coverage with `vendor/bin/phpunit --no-coverage`.
+
+### Checking style
+
+We use PHP-CS-Fixer to check for code style violations.
+
+To lint the code, simply run `composer lint`.
 
 #### Actions
 
@@ -75,4 +81,4 @@ We also utilize Github Actions. Currently it will:
 
 -----
 
-Thats it! Enjoy.
+That's it! Enjoy.

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.8",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "mockery/mockery": "^1.0",
         "orchestra/database": "~3.8 || ~4.0 || ~5.0 || ~6.0",
         "orchestra/testbench": "~3.8 || ~4.0 || ~5.0 || ~6.0",
@@ -61,6 +62,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "lint": "vendor/bin/php-cs-fixer fix",
         "test": "vendor/bin/phpunit",
         "test-html-cov": "vendor/bin/phpunit --coverage-html ./build/html/",
         "test-no-cov": "vendor/bin/phpunit --no-coverage"

--- a/src/ShopifyApp/Actions/InstallShop.php
+++ b/src/ShopifyApp/Actions/InstallShop.php
@@ -73,8 +73,8 @@ class InstallShop
         if (empty($code)) {
             return [
                 'completed' => false,
-                'url'       => $apiHelper->buildAuthUrl($grantMode, Util::getShopifyConfig('api_scopes', $shop)),
-                'shop_id'   => $shop->getId(),
+                'url' => $apiHelper->buildAuthUrl($grantMode, Util::getShopifyConfig('api_scopes', $shop)),
+                'shop_id' => $shop->getId(),
             ];
         }
 
@@ -90,15 +90,15 @@ class InstallShop
 
             return [
                 'completed' => true,
-                'url'       => null,
-                'shop_id'   => $shop->getId(),
+                'url' => null,
+                'shop_id' => $shop->getId(),
             ];
         } catch (Exception $e) {
             // Just return the default setting
             return [
                 'completed' => false,
-                'url'       => null,
-                'shop_id'   => null,
+                'url' => null,
+                'shop_id' => null,
             ];
         }
     }

--- a/src/ShopifyApp/Contracts/Commands/Shop.php
+++ b/src/ShopifyApp/Contracts/Commands/Shop.php
@@ -17,6 +17,7 @@ interface Shop
      *
      * @param  ShopDomainValue  $domain
      * @param  AccessTokenValue  $token
+     *
      * @return ShopIdValue
      */
     public function make(ShopDomainValue $domain, AccessTokenValue $token): ShopIdValue;

--- a/src/ShopifyApp/Http/Middleware/AuthProxy.php
+++ b/src/ShopifyApp/Http/Middleware/AuthProxy.php
@@ -69,7 +69,7 @@ class AuthProxy
         // Build a local signature
         $signatureLocal = Util::createHmac(
             [
-                'data'       => $query,
+                'data' => $query,
                 'buildQuery' => true,
             ],
             Util::getShopifyConfig('api_secret', $shop)

--- a/src/ShopifyApp/Http/Middleware/AuthWebhook.php
+++ b/src/ShopifyApp/Http/Middleware/AuthWebhook.php
@@ -30,8 +30,8 @@ class AuthWebhook
         $data = $request->getContent();
         $hmacLocal = Util::createHmac(
             [
-                'data'   => $data,
-                'raw'    => true,
+                'data' => $data,
+                'raw' => true,
                 'encode' => true,
             ],
             Util::getShopifyConfig('api_secret', $shop)

--- a/src/ShopifyApp/Http/Middleware/VerifyShopify.php
+++ b/src/ShopifyApp/Http/Middleware/VerifyShopify.php
@@ -285,7 +285,7 @@ class VerifyShopify
         return Redirect::route(
             Util::getShopifyConfig('route_names.authenticate.token'),
             [
-                'shop'   => ShopDomain::fromRequest($request)->toNative(),
+                'shop' => ShopDomain::fromRequest($request)->toNative(),
                 'target' => $target,
             ]
         );
@@ -404,8 +404,8 @@ class VerifyShopify
                 $timestamp = $request->header('X-Shop-Time');
 
                 $verify = [
-                    'shop'      => $shop,
-                    'hmac'      => $signature,
+                    'shop' => $shop,
+                    'hmac' => $signature,
                     'timestamp' => $timestamp,
                 ];
 

--- a/src/ShopifyApp/Http/Requests/StoreUsageCharge.php
+++ b/src/ShopifyApp/Http/Requests/StoreUsageCharge.php
@@ -35,9 +35,9 @@ class StoreUsageCharge extends FormRequest
         $validator->after(function (Validator $validator) {
             // Get the input values needed
             $data = [
-                'price'       => $this->request->get('price'),
+                'price' => $this->request->get('price'),
                 'description' => $this->request->get('description'),
-                'signature'   => $this->request->get('signature'),
+                'signature' => $this->request->get('signature'),
             ];
             if ($this->request->has('redirect')) {
                 $data['redirect'] = $this->request->get('redirect');
@@ -49,7 +49,7 @@ class StoreUsageCharge extends FormRequest
             // Confirm the charge hasn't been tampered with
             $signatureLocal = Util::createHmac(
                 [
-                    'data'       => $data,
+                    'data' => $data,
                     'buildQuery' => true,
                 ],
                 Util::getShopifyConfig('api_secret')
@@ -69,10 +69,10 @@ class StoreUsageCharge extends FormRequest
     public function rules(): array
     {
         return [
-            'signature'   => 'required|string',
-            'price'       => 'required|numeric',
+            'signature' => 'required|string',
+            'price' => 'required|numeric',
             'description' => 'required|string',
-            'redirect'    => 'nullable|string',
+            'redirect' => 'nullable|string',
         ];
     }
 }

--- a/src/ShopifyApp/Macros/TokenUrl.php
+++ b/src/ShopifyApp/Macros/TokenUrl.php
@@ -26,7 +26,7 @@ abstract class TokenUrl
         return [
             Util::getShopifyConfig('route_names.authenticate.token'),
             [
-                'shop'   => ShopDomain::fromRequest(Request::instance())->toNative(),
+                'shop' => ShopDomain::fromRequest(Request::instance())->toNative(),
                 'target' => URL::route($route, $params, $absolute),
             ],
         ];

--- a/src/ShopifyApp/Objects/Transfers/AbstractTransfer.php
+++ b/src/ShopifyApp/Objects/Transfers/AbstractTransfer.php
@@ -25,6 +25,7 @@ abstract class AbstractTransfer implements IteratorAggregate, JsonSerializable
     {
         // Does not exist, throw exception
         $className = get_class($this);
+
         throw new Exception("Property {$key} does not exist on transfer class {$className}");
     }
 
@@ -42,6 +43,7 @@ abstract class AbstractTransfer implements IteratorAggregate, JsonSerializable
     {
         // Not allowed, throw exception
         $className = get_class($this);
+
         throw new Exception("Setting property {$key} for transfer class {$className} is not allowed");
     }
 

--- a/src/ShopifyApp/Objects/Transfers/PlanDetails.php
+++ b/src/ShopifyApp/Objects/Transfers/PlanDetails.php
@@ -68,13 +68,13 @@ final class PlanDetails extends AbstractTransfer
     public function toArray(): array
     {
         return [
-            'name'          => $this->name,
-            'price'         => $this->price,
-            'interval'      => $this->interval,
-            'test'          => $this->test,
-            'trial_days'    => $this->trialDays,
-            'return_url'    => $this->returnUrl,
-            'terms'         => $this->terms,
+            'name' => $this->name,
+            'price' => $this->price,
+            'interval' => $this->interval,
+            'test' => $this->test,
+            'trial_days' => $this->trialDays,
+            'return_url' => $this->returnUrl,
+            'terms' => $this->terms,
             'capped_amount' => $this->cappedAmount,
         ];
     }

--- a/src/ShopifyApp/Objects/Values/SessionContext.php
+++ b/src/ShopifyApp/Objects/Values/SessionContext.php
@@ -107,7 +107,7 @@ final class SessionContext implements ValueObject
      *
      * @return bool
      */
-    public function isValid(?SessionContext $previousContext = null): bool
+    public function isValid(?self $previousContext = null): bool
     {
         // Confirm access token and session token are good
         $tokenCheck = ! $this->getAccessToken()->isEmpty() && ! $this->getSessionToken()->isNull();

--- a/src/ShopifyApp/Services/ApiHelper.php
+++ b/src/ShopifyApp/Services/ApiHelper.php
@@ -165,7 +165,7 @@ class ApiHelper implements IApiHelper
         // Setup the params
         $reqParams = array_merge(
             [
-                'limit'  => 250,
+                'limit' => 250,
                 'fields' => 'id,src',
             ],
             $params
@@ -269,6 +269,7 @@ class ApiHelper implements IApiHelper
 
     /**
      * {@inheritdoc}
+     *
      * @throws Exception
      */
     public function createChargeGraphQL(PlanDetailsTransfer $payload): ResponseAccess
@@ -300,16 +301,16 @@ class ApiHelper implements IApiHelper
         }
         ';
         $variables = [
-            'name'      => $payload->name,
+            'name' => $payload->name,
             'returnUrl' => $payload->returnUrl,
             'trialDays' => $payload->trialDays,
-            'test'      => $payload->test,
+            'test' => $payload->test,
             'lineItems' => [
                 [
                     'plan' => [
                         'appRecurringPricingDetails' => [
-                            'price'    => [
-                                'amount'       => $payload->price,
+                            'price' => [
+                                'amount' => $payload->price,
                                 'currencyCode' => 'USD',
                             ],
                             'interval' => $payload->interval,
@@ -326,6 +327,7 @@ class ApiHelper implements IApiHelper
 
     /**
      * {@inheritdoc}
+     *
      * @throws Exception
      */
     public function getWebhooks(array $params = []): ResponseAccess
@@ -359,6 +361,7 @@ class ApiHelper implements IApiHelper
 
     /**
      * {@inheritdoc}
+     *
      * @throws Exception
      */
     public function createWebhook(array $payload): ResponseAccess
@@ -388,10 +391,10 @@ class ApiHelper implements IApiHelper
         // to GraphQL-format topics ("RESOURCE_EVENT"), for pre-v17 compatibility
         $topic = Util::getGraphQLWebhookTopic($payload['topic']);
         $variables = [
-            'topic'               => $topic,
+            'topic' => $topic,
             'webhookSubscription' => [
                 'callbackUrl' => $payload['address'],
-                'format'      => 'JSON',
+                'format' => 'JSON',
             ],
         ];
 
@@ -402,6 +405,7 @@ class ApiHelper implements IApiHelper
 
     /**
      * {@inheritdoc}
+     *
      * @throws Exception
      */
     public function deleteWebhook(string $webhookId): ResponseAccess
@@ -439,7 +443,7 @@ class ApiHelper implements IApiHelper
             "/admin/recurring_application_charges/{$payload->chargeReference->toNative()}/usage_charges.json",
             [
                 'usage_charge' => [
-                    'price'       => $payload->price,
+                    'price' => $payload->price,
                     'description' => $payload->description,
                 ],
             ]
@@ -553,7 +557,7 @@ class ApiHelper implements IApiHelper
         ];
         foreach ($options as $fn) {
             $result = $fn();
-            if (! is_null($result)) {
+            if ($result !== null) {
                 return NullableShopDomain::fromNative($result);
             }
         }

--- a/src/ShopifyApp/Services/ChargeHelper.php
+++ b/src/ShopifyApp/Services/ChargeHelper.php
@@ -168,7 +168,7 @@ class ChargeHelper
     public function remainingDaysForPeriod(): int
     {
         $pastDaysForPeriod = $this->pastDaysForPeriod();
-        if (is_null($pastDaysForPeriod) ||
+        if ($pastDaysForPeriod === null ||
             ($pastDaysForPeriod === 0 && Carbon::parse($this->charge->cancelled_on)->lt(Carbon::today()))
         ) {
             return 0;

--- a/src/ShopifyApp/Storage/Models/Charge.php
+++ b/src/ShopifyApp/Storage/Models/Charge.php
@@ -37,9 +37,9 @@ class Charge extends Model
      * @var array
      */
     protected $casts = [
-        'test'          => 'bool',
+        'test' => 'bool',
         'capped_amount' => 'float',
-        'price'         => 'float',
+        'price' => 'float',
     ];
 
     /**
@@ -103,8 +103,8 @@ class Charge extends Model
     public function getTypeApiString($plural = false): string
     {
         $types = [
-            ChargeType::CREDIT()->toNative()    => 'application_credit',
-            ChargeType::CHARGE()->toNative()    => 'application_charge',
+            ChargeType::CREDIT()->toNative() => 'application_credit',
+            ChargeType::CHARGE()->toNative() => 'application_charge',
             ChargeType::RECURRING()->toNative() => 'recurring_application_charge',
         ];
         $type = $types[$this->getType()->toNative()];
@@ -151,7 +151,7 @@ class Charge extends Model
      */
     public function isTrial(): bool
     {
-        return ! is_null($this->trial_ends_on);
+        return $this->trial_ends_on !== null;
     }
 
     /**
@@ -213,7 +213,7 @@ class Charge extends Model
      */
     public function isCancelled(): bool
     {
-        return ! is_null($this->cancelled_on) || $this->isStatus(ChargeStatus::CANCELLED());
+        return $this->cancelled_on !== null || $this->isStatus(ChargeStatus::CANCELLED());
     }
 
     /**

--- a/src/ShopifyApp/Storage/Models/Plan.php
+++ b/src/ShopifyApp/Storage/Models/Plan.php
@@ -19,10 +19,10 @@ class Plan extends Model
      * @var array
      */
     protected $casts = [
-        'test'          => 'bool',
-        'on_install'    => 'bool',
+        'test' => 'bool',
+        'on_install' => 'bool',
         'capped_amount' => 'float',
-        'price'         => 'float',
+        'price' => 'float',
     ];
 
     /**
@@ -87,7 +87,7 @@ class Plan extends Model
     public function getTypeApiString($plural = false): string
     {
         $types = [
-            PlanType::ONETIME()->toNative()   => 'application_charge',
+            PlanType::ONETIME()->toNative() => 'application_charge',
             PlanType::RECURRING()->toNative() => 'recurring_application_charge',
         ];
         $type = $types[$this->getType()->toNative()];

--- a/src/ShopifyApp/Traits/AuthController.php
+++ b/src/ShopifyApp/Traits/AuthController.php
@@ -50,7 +50,7 @@ trait AuthController
             return View::make(
                 'shopify-app::auth.fullpage_redirect',
                 [
-                    'authUrl'    => $result['url'],
+                    'authUrl' => $result['url'],
                     'shopDomain' => $shopDomain->toNative(),
                 ]
             );
@@ -88,7 +88,7 @@ trait AuthController
             'shopify-app::auth.token',
             [
                 'shopDomain' => $shopDomain->toNative(),
-                'target'     => $cleanTarget,
+                'target' => $cleanTarget,
             ]
         );
     }

--- a/src/ShopifyApp/resources/database/factories/ChargeFactory.php
+++ b/src/ShopifyApp/resources/database/factories/ChargeFactory.php
@@ -9,9 +9,9 @@ use Osiset\ShopifyApp\Storage\Models\Charge;
 $factory->define(Charge::class, function (Faker $faker) {
     return [
         'charge_id' => $faker->randomNumber(8),
-        'name'      => $faker->word,
-        'price'     => $faker->randomFloat(),
-        'status'    => ChargeStatus::ACCEPTED()->toNative(),
+        'name' => $faker->word,
+        'price' => $faker->randomFloat(),
+        'status' => ChargeStatus::ACCEPTED()->toNative(),
     ];
 });
 
@@ -39,7 +39,7 @@ $factory->state(Charge::class, 'trial', function ($faker) {
     $days = $faker->numberBetween(7, 14);
 
     return [
-        'trial_days'    => $days,
+        'trial_days' => $days,
         'trial_ends_on' => Carbon::today()->addDays($days),
     ];
 });

--- a/src/ShopifyApp/resources/database/factories/PlanFactory.php
+++ b/src/ShopifyApp/resources/database/factories/PlanFactory.php
@@ -7,7 +7,7 @@ use Osiset\ShopifyApp\Storage\Models\Plan;
 
 $factory->define(Plan::class, function (Faker $faker) {
     return [
-        'name'  => $faker->word,
+        'name' => $faker->word,
         'price' => $faker->randomFloat(),
     ];
 });
@@ -15,7 +15,7 @@ $factory->define(Plan::class, function (Faker $faker) {
 $factory->state(Plan::class, 'usage', function ($faker) {
     return [
         'capped_amount' => $faker->randomFloat(),
-        'terms'         => $faker->sentence,
+        'terms' => $faker->sentence,
     ];
 });
 

--- a/src/ShopifyApp/resources/database/factories/ShopFactory.php
+++ b/src/ShopifyApp/resources/database/factories/ShopFactory.php
@@ -7,9 +7,9 @@ $model = Config::get('auth.providers.users.model');
 
 $factory->define($model, function (Faker $faker) {
     return [
-        'name'     => "{$faker->domainWord}.myshopify.com",
+        'name' => "{$faker->domainWord}.myshopify.com",
         'password' => str_replace('-', '', $faker->uuid),
-        'email'    => $faker->email,
+        'email' => $faker->email,
     ];
 });
 

--- a/tests/Actions/ActivatePlanTest.php
+++ b/tests/Actions/ActivatePlanTest.php
@@ -37,8 +37,8 @@ class ActivatePlanTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_recurring')->create([
             'charge_id' => 12345,
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         // Setup API stub
@@ -69,8 +69,8 @@ class ActivatePlanTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_recurring')->create([
             'charge_id' => 12345,
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         // Setup API stub

--- a/tests/Actions/ActivateUsageChargeTest.php
+++ b/tests/Actions/ActivateUsageChargeTest.php
@@ -38,8 +38,8 @@ class ActivateUsageChargeTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_recurring')->create([
             'charge_id' => 12345,
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         // Create the transfer
@@ -79,8 +79,8 @@ class ActivateUsageChargeTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_onetime')->create([
             'charge_id' => 12345,
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         // Create the transfer
@@ -108,8 +108,8 @@ class ActivateUsageChargeTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_recurring')->create([
             'charge_id' => 12345,
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         // Create the transfer

--- a/tests/Actions/AfterAuthorizeTest.php
+++ b/tests/Actions/AfterAuthorizeTest.php
@@ -32,11 +32,11 @@ class AfterAuthorizeTest extends TestCase
         $jobClass = AfterAuthorizeJob::class;
         $this->app['config']->set('shopify-app.after_authenticate_job', [
             [
-                'job'    => $jobClass,
+                'job' => $jobClass,
                 'inline' => false,
             ],
             [
-                'job'    => $jobClass,
+                'job' => $jobClass,
                 'inline' => false,
             ],
         ]);
@@ -58,7 +58,7 @@ class AfterAuthorizeTest extends TestCase
         // Create the config
         $jobClass = AfterAuthorizeJob::class;
         $this->app['config']->set('shopify-app.after_authenticate_job', [
-            'job'    => $jobClass,
+            'job' => $jobClass,
             'inline' => true,
         ]);
 

--- a/tests/Actions/AuthenticateShopTest.php
+++ b/tests/Actions/AuthenticateShopTest.php
@@ -56,12 +56,12 @@ class AuthenticateShopTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
-                'shop'      => 'mystore123.myshopify.com',
-                'hmac'      => 'badhmac',
+                'shop' => 'mystore123.myshopify.com',
+                'hmac' => 'badhmac',
                 'timestamp' => '1565631587',
-                'code'      => '123',
-                'locale'    => 'de',
-                'state'     => '3.14',
+                'code' => '123',
+                'locale' => 'de',
+                'state' => '3.14',
             ],
             // Request Params
             null,
@@ -93,12 +93,12 @@ class AuthenticateShopTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
-                'shop'      => 'mystore123.myshopify.com',
-                'hmac'      => '3d9768c9cc44b8bd66125cb82b6a59a3d835432f560d19b3f79b9fc696ef6396',
+                'shop' => 'mystore123.myshopify.com',
+                'hmac' => '3d9768c9cc44b8bd66125cb82b6a59a3d835432f560d19b3f79b9fc696ef6396',
                 'timestamp' => '1565631587',
-                'code'      => '123',
-                'locale'    => 'de',
-                'state'     => '3.14',
+                'code' => '123',
+                'locale' => 'de',
+                'state' => '3.14',
             ],
             // Request Params
             null,

--- a/tests/Actions/CancelChargeTest.php
+++ b/tests/Actions/CancelChargeTest.php
@@ -39,8 +39,8 @@ class CancelChargeTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_recurring')->create([
             'charge_id' => $chargeRef->toNative(),
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         $result = call_user_func($this->action, $chargeRef);
@@ -69,8 +69,8 @@ class CancelChargeTest extends TestCase
         // Create a charge for the plan and shop
         factory(Charge::class)->states('type_usage')->create([
             'charge_id' => $chargeRef->toNative(),
-            'plan_id'   => $plan->getId()->toNative(),
-            'user_id'   => $shop->getId()->toNative(),
+            'plan_id' => $plan->getId()->toNative(),
+            'user_id' => $shop->getId()->toNative(),
         ]);
 
         call_user_func($this->action, $chargeRef);

--- a/tests/Actions/CreateWebhooksTest.php
+++ b/tests/Actions/CreateWebhooksTest.php
@@ -25,7 +25,7 @@ class CreateWebhooksTest extends TestCase
         // Create the config
         $webhooks = [
             [
-                'topic'   => 'ORDERS_CREATE',
+                'topic' => 'ORDERS_CREATE',
                 'address' => 'https://localhost/webhooks/orders-create',
             ],
         ];
@@ -58,15 +58,15 @@ class CreateWebhooksTest extends TestCase
         // Create the config
         $webhooks = [
             [
-                'topic'   => 'ORDERS_CREATE',
+                'topic' => 'ORDERS_CREATE',
                 'address' => 'https://localhost/webhooks/orders-create',
             ],
             [
-                'topic'   => 'ORDERS_CREATE',
+                'topic' => 'ORDERS_CREATE',
                 'address' => 'https://localhost/webhooks/orders-create-different',
             ],
             [
-                'topic'   => 'APP_UNINSTALLED',
+                'topic' => 'APP_UNINSTALLED',
                 'address' => 'http://apple.com/uninstall',
             ],
         ];

--- a/tests/Actions/DispatchWebhooksTest.php
+++ b/tests/Actions/DispatchWebhooksTest.php
@@ -49,11 +49,11 @@ class DispatchWebhooksTest extends TestCase
         // Create the config
         $this->app['config']->set('shopify-app.webhooks', [
             [
-                'topic'   => 'orders/create',
+                'topic' => 'orders/create',
                 'address' => 'https://localhost/webhooks/orders-create',
             ],
             [
-                'topic'   => 'app/uninstalled',
+                'topic' => 'app/uninstalled',
                 'address' => 'http://apple.com/uninstall',
             ],
         ]);
@@ -84,11 +84,11 @@ class DispatchWebhooksTest extends TestCase
         // Create the config
         $this->app['config']->set('shopify-app.webhooks', [
             [
-                'topic'   => 'orders/create',
+                'topic' => 'orders/create',
                 'address' => 'https://localhost/webhooks/orders-create',
             ],
             [
-                'topic'   => 'app/uninstalled',
+                'topic' => 'app/uninstalled',
                 'address' => 'http://apple.com/uninstall',
             ],
         ]);

--- a/tests/Console/WebhookJobMakeCommandTest.php
+++ b/tests/Console/WebhookJobMakeCommandTest.php
@@ -15,7 +15,7 @@ class WebhookJobMakeCommandTest extends TestCase
             ->artisan(
                 'shopify-app:make:webhook',
                 [
-                    'name'  => 'OrdersCreate',
+                    'name' => 'OrdersCreate',
                     'topic' => 'orders/create',
                 ]
             )
@@ -36,8 +36,8 @@ class WebhookJobMakeCommandTest extends TestCase
         $method->setAccessible(true);
 
         $jobs = [
-            'OrdersCreateJob'       => 'orders-create',
-            'OrdersCreate'          => 'orders-create',
+            'OrdersCreateJob' => 'orders-create',
+            'OrdersCreate' => 'orders-create',
             'OrdersCreateCustomJob' => 'orders-create-custom',
         ];
         foreach ($jobs as $className => $route) {

--- a/tests/Http/Middleware/AuthProxyTest.php
+++ b/tests/Http/Middleware/AuthProxyTest.php
@@ -26,22 +26,22 @@ class AuthProxyTest extends TestCase
 
         // From Shopify's docs
         $this->queryParams = [
-            'extra'       => ['1', '2'],
-            'shop'        => 'shop-name.myshopify.com',
+            'extra' => ['1', '2'],
+            'shop' => 'shop-name.myshopify.com',
             'path_prefix' => '/apps/awesome_reviews',
-            'timestamp'   => '1317327555',
-            'signature'   => 'a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3',
+            'timestamp' => '1317327555',
+            'signature' => 'a9718877bea71c2484f91608a7eaea1532bdf71f5c56825065fa4ccabe549ef3',
         ];
 
         // Array parameter format
         $this->queryStringArrayFormat = 'extra[]=1&extra[]=2&shop=shop-name.myshopify.com&path_prefix=%2Fapps%2Fawesome_reviews&timestamp=1317327555&signature=6f4b878d5340128aab03a234676dba228432b0b8b72863828ec143e4c5772124';
 
         $this->queryParamsArrayFormat = [
-            'extra'       => ['1', '2'],
-            'shop'        => 'shop-name.myshopify.com',
+            'extra' => ['1', '2'],
+            'shop' => 'shop-name.myshopify.com',
             'path_prefix' => '/apps/awesome_reviews',
-            'timestamp'   => '1317327555',
-            'signature'   => '6f4b878d5340128aab03a234676dba228432b0b8b72863828ec143e4c5772124',
+            'timestamp' => '1317327555',
+            'signature' => '6f4b878d5340128aab03a234676dba228432b0b8b72863828ec143e4c5772124',
         ];
 
         // Set the app secret to match Shopify's docs

--- a/tests/Http/Middleware/VerifyShopifyTest.php
+++ b/tests/Http/Middleware/VerifyShopifyTest.php
@@ -19,10 +19,10 @@ class VerifyShopifyTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
-                'shop'      => 'mystore123.myshopify.com',
-                'hmac'      => '9f4d79eb5ab1806c390b3dda0bfc7be714a92df165d878f22cf3cc8145249ca8',
+                'shop' => 'mystore123.myshopify.com',
+                'hmac' => '9f4d79eb5ab1806c390b3dda0bfc7be714a92df165d878f22cf3cc8145249ca8',
                 'timestamp' => 'oops',
-                'code'      => 'oops',
+                'code' => 'oops',
             ],
             // Request Params
             null,
@@ -114,7 +114,7 @@ class VerifyShopifyTest extends TestCase
             // Server vars
             [
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
-                'HTTP_X-Shop-Domain'    => $shop->name,
+                'HTTP_X-Shop-Domain' => $shop->name,
             ]
         );
 
@@ -143,7 +143,7 @@ class VerifyShopifyTest extends TestCase
             null,
             // Server vars
             [
-                'HTTP_Authorization'    => "Bearer {$this->buildToken()}",
+                'HTTP_Authorization' => "Bearer {$this->buildToken()}",
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
             ]
         );
@@ -161,7 +161,7 @@ class VerifyShopifyTest extends TestCase
             // Query Params
             [
                 'token' => $this->buildToken(),
-                'shop'  => 'non-existent.myshopify.com',
+                'shop' => 'non-existent.myshopify.com',
             ],
             // Request Params
             null,
@@ -199,7 +199,7 @@ class VerifyShopifyTest extends TestCase
             null,
             // Server vars
             [
-                'HTTP_Authorization'    => "Bearer {$this->buildToken()}",
+                'HTTP_Authorization' => "Bearer {$this->buildToken()}",
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
             ]
         );
@@ -252,7 +252,7 @@ class VerifyShopifyTest extends TestCase
             null,
             // Server vars
             [
-                'HTTP_Authorization'    => "Bearer {$this->buildToken()}OOPS",
+                'HTTP_Authorization' => "Bearer {$this->buildToken()}OOPS",
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
             ]
         );
@@ -284,7 +284,7 @@ class VerifyShopifyTest extends TestCase
             null,
             // Server vars
             [
-                'HTTP_Authorization'    => "Bearer {$token}",
+                'HTTP_Authorization' => "Bearer {$token}",
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
             ]
         );
@@ -309,7 +309,7 @@ class VerifyShopifyTest extends TestCase
             null,
             // Server vars
             [
-                'HTTP_Authorization'    => "Bearer {$token}",
+                'HTTP_Authorization' => "Bearer {$token}",
                 'HTTP_X-Requested-With' => 'XMLHttpRequest',
             ]
         );

--- a/tests/Http/Requests/StoreUsageChargeTest.php
+++ b/tests/Http/Requests/StoreUsageChargeTest.php
@@ -23,7 +23,7 @@ class StoreUsageChargeTest extends TestCase
     public function testFailsForInvalidSignature(): void
     {
         $data = [
-            'price'       => '1.00',
+            'price' => '1.00',
             'description' => 'Testing',
         ];
 
@@ -41,9 +41,9 @@ class StoreUsageChargeTest extends TestCase
     public function testPasses(): void
     {
         $data = [
-            'price'       => '1.00',
+            'price' => '1.00',
             'description' => 'Testing',
-            'redirect'    => '/',
+            'redirect' => '/',
         ];
         $signature = Util::createHmac(['data' => $data, 'buildQuery' => true], $this->app['config']->get('shopify-app.api_secret'));
         $data['signature'] = $signature->toNative();

--- a/tests/Messaging/Jobs/AppUninstalledTest.php
+++ b/tests/Messaging/Jobs/AppUninstalledTest.php
@@ -22,7 +22,7 @@ class AppUninstalledTest extends TestCase
         factory(Charge::class)->states('type_recurring')->create([
             'plan_id' => $plan->getId()->toNative(),
             'user_id' => $shop->getId()->toNative(),
-            'status'  => ChargeStatus::ACTIVE()->toNative(),
+            'status' => ChargeStatus::ACTIVE()->toNative(),
         ]);
 
         // Ensure shop is not trashed, and has charges

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -200,7 +200,7 @@ class ApiHelperTest extends TestCase
         ApiStub::stubResponses(['post_webhook']);
 
         $data = $shop->apiHelper()->createWebhook([
-            'topic'   => 'ORDERS_CREATE',
+            'topic' => 'ORDERS_CREATE',
             'address' => 'https://localhost/webhook/orders-create',
         ]);
         $this->assertInstanceOf(ResponseAccess::class, $data);

--- a/tests/Services/ChargeHelperTest.php
+++ b/tests/Services/ChargeHelperTest.php
@@ -56,7 +56,7 @@ class ChargeHelperTest extends TestCase
     {
         // Seed
         $seed = $this->seedData([
-            'trial_days'    => 7,
+            'trial_days' => 7,
             'trial_ends_on' => $this->now->today()->addDays(7)->format('Y-m-d'),
         ]);
         $this->chargeHelper->useCharge($seed['charge']->getReference());
@@ -72,7 +72,7 @@ class ChargeHelperTest extends TestCase
     {
         // Seed
         $seed = $this->seedData([
-            'trial_days'    => 0,
+            'trial_days' => 0,
         ]);
         $this->chargeHelper->useCharge($seed['charge']->getReference());
 
@@ -87,11 +87,11 @@ class ChargeHelperTest extends TestCase
     {
         // Seed
         $seed = $this->seedData([
-            'status'        => ChargeStatus::CANCELLED()->toNative(),
-            'trial_days'    => 7,
+            'status' => ChargeStatus::CANCELLED()->toNative(),
+            'trial_days' => 7,
             'trial_ends_on' => '2020-01-10',
-            'cancelled_on'  => '2020-01-05',
-            'expires_on'    => '2020-01-11',
+            'cancelled_on' => '2020-01-05',
+            'expires_on' => '2020-01-11',
         ]);
         $this->chargeHelper->useCharge($seed['charge']->getReference());
 
@@ -180,16 +180,16 @@ class ChargeHelperTest extends TestCase
             array_merge(
                 [
                     'charge_id' => 12345,
-                    'plan_id'   => $plan->getId()->toNative(),
-                    'user_id'   => $shop->getId()->toNative(),
+                    'plan_id' => $plan->getId()->toNative(),
+                    'user_id' => $shop->getId()->toNative(),
                 ],
                 $extraCharge
             )
         );
 
         return [
-            'plan'   => $plan,
-            'shop'   => $shop,
+            'plan' => $plan,
+            'shop' => $shop,
             'charge' => $charge,
         ];
     }

--- a/tests/Stubs/Api.php
+++ b/tests/Stubs/Api.php
@@ -35,10 +35,10 @@ class Api extends BasicShopifyAPI
         }
 
         return [
-            'errors'     => $errors,
-            'exception'  => $exception,
-            'body'       => new ResponseAccess($response),
-            'status'     => Response::HTTP_OK,
+            'errors' => $errors,
+            'exception' => $exception,
+            'body' => new ResponseAccess($response),
+            'status' => Response::HTTP_OK,
         ];
     }
 
@@ -59,11 +59,11 @@ class Api extends BasicShopifyAPI
         }
 
         return [
-            'errors'     => $errors,
-            'exception'  => $exception,
-            'response'   => $response,
-            'status'     => Response::HTTP_OK,
-            'body'       => new ResponseAccess($response),
+            'errors' => $errors,
+            'exception' => $exception,
+            'response' => $response,
+            'status' => Response::HTTP_OK,
+            'body' => new ResponseAccess($response),
         ];
     }
 

--- a/tests/Stubs/Kernel.php
+++ b/tests/Stubs/Kernel.php
@@ -23,17 +23,17 @@ class Kernel extends \Orchestra\Testbench\Http\Kernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth'       => Authenticate::class,
+        'auth' => Authenticate::class,
         'auth.basic' => AuthenticateWithBasicAuth::class,
-        'bindings'   => SubstituteBindings::class,
-        'can'        => Authorize::class,
-        'guest'      => RedirectIfAuthenticated::class,
-        'throttle'   => ThrottleRequests::class,
+        'bindings' => SubstituteBindings::class,
+        'can' => Authorize::class,
+        'guest' => RedirectIfAuthenticated::class,
+        'throttle' => ThrottleRequests::class,
 
         // Added for testing
         'verify.shopify' => VerifyShopify::class,
-        'auth.webhook'   => AuthWebhook::class,
-        'auth.proxy'     => AuthProxy::class,
-        'billable'       => Billable::class,
+        'auth.webhook' => AuthWebhook::class,
+        'auth.proxy' => AuthProxy::class,
+        'billable' => Billable::class,
     ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,6 +38,7 @@ abstract class TestCase extends OrchestraTestCase
 
     /**
      * Carbon time.
+     *
      * @var CarbonImmutable
      */
     protected $now;
@@ -58,15 +59,15 @@ abstract class TestCase extends OrchestraTestCase
         // Token defaults
         $now = Carbon::now()->unix();
         $this->tokenDefaults = [
-            'iss'  => 'https://shop-name.myshopify.com/admin',
+            'iss' => 'https://shop-name.myshopify.com/admin',
             'dest' => 'https://shop-name.myshopify.com',
-            'aud'  => Util::getShopifyConfig('api_key'),
-            'sub'  => '123',
-            'exp'  => $now + 60,
-            'nbf'  => $now,
-            'iat'  => $now,
-            'jti'  => '00000000-0000-0000-0000-000000000000',
-            'sid'  => '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+            'aud' => Util::getShopifyConfig('api_key'),
+            'sub' => '123',
+            'exp' => $now + 60,
+            'nbf' => $now,
+            'iat' => $now,
+            'jti' => '00000000-0000-0000-0000-000000000000',
+            'sid' => '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
         ];
     }
 
@@ -90,9 +91,9 @@ abstract class TestCase extends OrchestraTestCase
         // Use memory SQLite, cleans it self up
         $app['config']->set('database.default', 'sqlite');
         $app['config']->set('database.connections.sqlite', [
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
-            'prefix'   => '',
+            'prefix' => '',
         ]);
         $app['config']->set('auth.providers.users.model', UserStub::class);
     }

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -38,9 +38,9 @@ class AuthControllerTest extends TestCase
         // HMAC for regular tests
         $hmac = '6f16da24e8185e717f22a3373a1928fcaea7ea2401be40ab0d160f5bed7fe55a';
         $hmacParams = [
-            'hmac'      => $hmac,
-            'shop'      => 'example.myshopify.com',
-            'code'      => '1234678',
+            'hmac' => $hmac,
+            'shop' => 'example.myshopify.com',
+            'code' => '1234678',
             'timestamp' => '1337178173',
         ];
 
@@ -54,9 +54,9 @@ class AuthControllerTest extends TestCase
         ApiStub::stubResponses(['access_token_grant']);
 
         $hmacParams = [
-            'hmac'      => 'badhmac',
-            'shop'      => 'example.myshopify.com',
-            'code'      => '1234678',
+            'hmac' => 'badhmac',
+            'shop' => 'example.myshopify.com',
+            'code' => '1234678',
             'timestamp' => '1337178173',
         ];
 

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -70,7 +70,7 @@ class BillingControllerTest extends TestCase
             "/billing/process/{$plan->id}",
             [
                 'charge_id' => 1,
-                'shop'      => $shop->getDomain()->toNative(),
+                'shop' => $shop->getDomain()->toNative(),
             ]
         );
 

--- a/tests/Traits/WebhookControllerTest.php
+++ b/tests/Traits/WebhookControllerTest.php
@@ -21,7 +21,7 @@ class WebhookControllerTest extends TestCase
         // Mock headers that match Shopify
         $shop = factory($this->model)->create(['name' => 'example.myshopify.com']);
         $headers = [
-            'HTTP_CONTENT_TYPE'          => 'application/json',
+            'HTTP_CONTENT_TYPE' => 'application/json',
             'HTTP_X_SHOPIFY_SHOP_DOMAIN' => $shop->name,
             'HTTP_X_SHOPIFY_HMAC_SHA256' => 'hvTE9wpDzMcDnPEuHWvYZ58ElKn5vHs0LomurfNIuUc=', // Matches fixture data and API secret
         ];

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -87,9 +87,9 @@ class UtilTest extends TestCase
     {
         // REST-format topics are changed to the GraphQL format
         $topics = [
-            'app/uninstalled'            => 'APP_UNINSTALLED',
+            'app/uninstalled' => 'APP_UNINSTALLED',
             'orders/partially_fulfilled' => 'ORDERS_PARTIALLY_FULFILLED',
-            'order_transactions/create'  => 'ORDER_TRANSACTIONS_CREATE',
+            'order_transactions/create' => 'ORDER_TRANSACTIONS_CREATE',
         ];
 
         foreach ($topics as $restTopic => $graphQLTopic) {


### PR DESCRIPTION
This PR enables PHP-CS-Fixer in Github Action.
The coding rules and ruleset are way more flexible than in StyleCI.

To fix the violations, just run `composer lint`

---

Example of failing linting: https://github.com/osiset/laravel-shopify/pull/883/checks?check_run_id=3030951877

---

651a7f679ace85c2767746a3a36fe16203055d0f fix all code violations

---

Of course, StyleCI service needs to be disabled.
