### PR TITLE
Uses codecov.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 .gitignore               export-ignore
 .php-cs-fixer.dist.php   export-ignore
 CODE_OF_CONDUCT.md       export-ignore
+codecov.yml              export-ignore
 phpunit.xml              export-ignore
 CONTRIBUTING.md          export-ignore
 CONTRIBUTORS.txt         export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,5 @@ jobs:
         run: vendor/bin/phpstan --memory-limit 0
 
       - name: Upload coverage results
+        uses: codecov/codecov-action@v1
         if: matrix.coverage != 'none'
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          composer require php-coveralls/php-coveralls --dev
-          vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run static code analysis
         if: matrix.analysis == true
-        run: vendor/bin/phpstan --memory-limit 0
+        run: vendor/bin/phpstan --memory-limit=-1
 
       - name: Upload coverage results
         uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Laravel Shopify App
 
 ![Tests](https://github.com/osiset/laravel-shopify/workflows/Package%20Test/badge.svg?branch=master)
-[![Coverage](https://coveralls.io/repos/github/osiset/laravel-shopify/badge.svg?branch=master)](https://coveralls.io/github/osiset/laravel-shopify?branch=master)
-[![StyleCI](https://styleci.io/repos/96462257/shield?style=flat)](https://github.styleci.io/repos/96462257)
+[![codecov.io](https://img.shields.io/codecov/c/github/osiset/laravel-shopify.svg?style=flat-square)](https://codecov.io/github/osiset/laravel-shopify?branch=master)
 [![License](https://poser.pugx.org/osiset/laravel-shopify/license)](https://packagist.org/packages/osiset/laravel-shopify)
 
 ----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Shopify App
 
 ![Tests](https://github.com/osiset/laravel-shopify/workflows/Package%20Test/badge.svg?branch=master)
-[![codecov.io](https://img.shields.io/codecov/c/github/osiset/laravel-shopify.svg?style=flat-square)](https://codecov.io/github/osiset/laravel-shopify?branch=master)
+[![codecov](https://codecov.io/gh/osiset/laravel-shopify/branch/master/graph/badge.svg?token=qqUuLItqJj)](https://codecov.io/gh/osiset/laravel-shopify)
 [![License](https://poser.pugx.org/osiset/laravel-shopify/license)](https://packagist.org/packages/osiset/laravel-shopify)
 
 ----

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Uses codecov instead of coversall