### PR TITLE
:bug: Retain host parameter after successful install

### DIFF
--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -58,7 +58,10 @@ trait AuthController
             // Go to home route
             return Redirect::route(
                 Util::getShopifyConfig('route_names.home'),
-                ['shop' => $shopDomain->toNative()]
+                [
+                    'shop' => $shopDomain->toNative(),
+                    'host' => $request->host
+                ]
             );
         }
     }

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -60,7 +60,7 @@ trait AuthController
                 Util::getShopifyConfig('route_names.home'),
                 [
                     'shop' => $shopDomain->toNative(),
-                    'host' => $request->host
+                    'host' => $request->host,
                 ]
             );
         }

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -32,6 +32,7 @@
                 var app = createApp({
                     apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
                     shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
+                    host: "{{ \Request::get('host') }}",
                     forceRedirect: true,
                 });
             </script>


### PR DESCRIPTION
AppBridge 2.0 (now required for successful submission) requires the host parameter, after redirect it is not available on the URL any longer. Include it here to make it easily available.

I'm not using the supplied views, mine are custom, and I need the host parameter to be more readily available when I instantiate appbridge.  This works fine.