### PR TITLE
Add route autocompletion support for the Laravel Idea plugin

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://laravel-ide.com/schema/laravel-ide-v1.json",
+    "completion": {
+        "route": [
+            {
+                "methods": ["tokenRedirect"],
+                "classes": ["Redirect", "Redirector"],
+                "parameters": [1]
+            },
+            {
+                "methods": ["tokenRoute"],
+                "classes": ["URL", "UrlGenerator"],
+                "parameters": [1]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
The popular [Laravel Idea PhpStorm plugin](https://laravel-idea.com/) allows custom configuration for the autocompletions through the use of a [config file `ide.json`](https://laravel-idea.com/docs/ide_json). This PR adds that file so that the token route macros will autocomplete the route names:

![image](https://user-images.githubusercontent.com/748444/126704554-5f8d4577-118d-4a0d-8e87-5100fe50772b.png)

![image](https://user-images.githubusercontent.com/748444/126704593-a0ade8f4-d46d-4336-8f81-b9f67735ff61.png)
