### PR TITLE
shop domain is missing while redirecting to billing route

### DIFF
--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -41,7 +41,7 @@ trait BillingController
         GetPlanUrl $getPlanUrl
     ): ViewView {
         // Get the shop
-        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
+        $shop = ($request->get('shop')) ? $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop'))) : auth()->user();
 
         // Get the plan URL for redirect
         $url = $getPlanUrl(
@@ -73,7 +73,7 @@ trait BillingController
         ActivatePlan $activatePlan
     ): RedirectResponse {
         // Get the shop
-        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->query('shop')));
+        $shop = ($request->get('shop')) ? $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop'))) : auth()->user();
 
         // Activate the plan and save
         $result = $activatePlan(


### PR DESCRIPTION
Shop domain is missing in query string

- While redirecting to billing route.
- Identify this issue while redirecting a user(shop) to billing route with Plan Id after installation of app to manage multi billing plans.
- It will resolve this issue #969 