### PR TITLE
Bugfix incorrect api_key in SessionToken function

### DIFF
--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -251,7 +251,7 @@ final class SessionToken implements SessionTokenValue
     protected function verifyValidity(): void
     {
         Assert::that($this->iss)->contains($this->dest, self::EXCEPTION_INVALID);
-        Assert::that($this->aud)->eq(Util::getShopifyConfig('api_key'), self::EXCEPTION_INVALID);
+        Assert::that($this->aud)->eq(Util::getShopifyConfig('api_key', $this->getShopDomain()), self::EXCEPTION_INVALID);
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where the verifyValidity() function checks the api token against the global api_key instead of any shop specific token.
Also fixes an infinite loop error that was occurring for myself, possibly related to: https://github.com/osiset/laravel-shopify/issues/962