### PR TITLE
Event to notify Successful App Installation on the Store.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "funeralzone/valueobjects": "^0.5",
         "jenssegers/agent": "^2.6",
-        "laravel/framework": "^7.0 || ^8.0",
+        "laravel/framework": "^7.0 || ^8.0 || ^9.0",
         "osiset/basic-shopify-api": "^9.0 || ^10.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "funeralzone/valueobjects": "^0.5",
         "jenssegers/agent": "^2.6",
         "laravel/framework": "^7.0 || ^8.0 || ^9.0",
-        "osiset/basic-shopify-api": "^9.0 || ^10.0"
+        "osiset/basic-shopify-api": "dev-master"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.8",
@@ -73,5 +73,11 @@
         "forum": "https://github.com/osiset/laravel-shopify/discussions",
         "wiki": "https://github.com/osiset/laravel-shopify/wiki",
         "source": "https://github.com/osiset/laravel-shopify"
-    }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/EzeeSpace/Basic-Shopify-API.git"
+        }
+    ]
 }

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Actions;
 use Exception;
 use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Messaging\Events\AppInstalled;
 use Osiset\ShopifyApp\Objects\Enums\AuthMode;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
@@ -87,6 +88,8 @@ class InstallShop
             // Get the data and set the access token
             $data = $apiHelper->getAccessData($code);
             $this->shopCommand->setAccessToken($shop->getId(), AccessToken::fromNative($data['access_token']));
+
+            AppInstalled::dispatch($shop);
 
             return [
                 'completed' => true,

--- a/src/Messaging/Events/AppInstalled.php
+++ b/src/Messaging/Events/AppInstalled.php
@@ -28,4 +28,9 @@ class AppInstalled
     {
         $this->shop = $shop;
     }
+
+    public function getShop()
+    {
+        return $this->shop;
+    }
 }

--- a/src/Messaging/Events/AppInstalled.php
+++ b/src/Messaging/Events/AppInstalled.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Osiset\ShopifyApp\Messaging\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+
+class AppInstalled
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Shop's instance.
+     *
+     * @var string
+     */
+    protected $shop;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param IShopModel $shop The shop.
+     *
+     * @return void
+     */
+    public function __construct(IShopModel $shop)
+    {
+        $this->shop = $shop;
+    }
+}

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -54,8 +54,20 @@ trait AuthController
                 throw new MissingAuthUrlException('Missing auth url');
             }
 
-            // Just return them straight to the OAUTH flow.
-            return Redirect::to($result['url']);
+            $shopDomain = $shopDomain->toNative();
+            $shopOrigin = $shopDomain ?? $request->user()->name;
+
+            return View::make(
+                'shopify-app::auth.fullpage_redirect',
+                [
+                    'apiKey' => Util::getShopifyConfig('api_key', $shopOrigin),
+                    'appBridgeVersion' => Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '',
+                    'authUrl' => $result['url'],
+                    'host' => $request->host ?? base64_encode($shopOrigin.'/admin'),
+                    'shopDomain' => $shopDomain,
+                    'shopOrigin' => $shopOrigin,
+                ]
+            );
         } else {
             // Go to home route
             return Redirect::route(

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -1,31 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <base target="_top">
+<head>
+    <meta charset="utf-8">
+    <base target="_top">
 
-        <title>Redirecting...</title>
+    <title>Redirecting...</title>
 
-        <script type="text/javascript">
-            document.addEventListener('DOMContentLoaded', function () {
-                var redirectUrl = "{!! $authUrl !!}";
-                if (window.top == window.self) {
-                    // If the current window is the 'parent', change the URL by setting location.href
-                    window.top.location.href = redirectUrl;
-                } else {
-                    // If the current window is the 'child', change the parent's URL with postMessage
-                    normalizedLink = document.createElement('a');
-                    normalizedLink.href = redirectUrl;
+    <script src="https://unpkg.com/@shopify/app-bridge{!! $appBridgeVersion !!}"></script>
+    <script src="https://unpkg.com/@shopify/app-bridge-utils{!! $appBridgeVersion !!}"></script>
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function () {
+            var redirectUrl = "{!! $authUrl !!}";
+            if (window.top == window.self) {
+                // If the current window is the 'parent', change the URL by setting location.href
+                window.top.location.href = redirectUrl;
+            } else {
+                // If the current window is the 'child', change the parent's URL with postMessage
+                normalizedLink = document.createElement('a');
+                normalizedLink.href = redirectUrl;
 
-                    data = JSON.stringify({
-                        message: 'Shopify.API.remoteRedirect',
-                        data: { location: redirectUrl },
-                    });
-                    window.parent.postMessage(data, "https://{{ $shopDomain }}");
-                }
-            });
-        </script>
-    </head>
-    <body>
-    </body>
+                var AppBridge = window['app-bridge'];
+                var createApp = AppBridge.default;
+                var Redirect = AppBridge.actions.Redirect;
+                var app = createApp({
+                    apiKey: "{{!! $apiKey !!}}",
+                    shopOrigin: "{{!! $shopOrigin !!}}",
+                    host: "{{!! $host !!}}",
+                });
+
+                var redirect = Redirect.create(app);
+                redirect.dispatch(Redirect.Action.REMOTE, normalizedLink.href);
+            }
+        });
+    </script>
+</head>
+<body>
+</body>
 </html>


### PR DESCRIPTION
The `AppInstalled` event will be triggered after the installation of App on the store. This can be used to run jobs after successful installation. For example, fetching data from the store that is needed by the application.

Here is an example of how to set up a Listener and subscribe to it on the project's EventServiceProvider.

```php

<?php

namespace App\Listeners;

use Osiset\ShopifyApp\Messaging\Events\AppInstalled;

class AppInstalledEventListener
{
    /**
     * Handle AppInstalled Event.
     *
     * @param  Osiset\ShopifyApp\Messaging\Events\AppInstalled $event
     * @return void
     */
    public function handle(AppInstalled $event)
    {
            $shop = $event->getShop();
            // Get Shop Details
            // Get Products
            // Get Collections
            // etc...
    }
}
```

Once your listener has been defined, you may register it within your application's `EventServiceProvider`:

```php
<?php

namespace App\Providers;

use App\Listeners\AppInstalledEventListener;
use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
use Osiset\ShopifyApp\Messaging\Events\AppInstalled;

class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        AppInstalled::class => [
            AppInstalledEventListener::class,
        ],
    ];
}
```