### PR TITLE
Update the API version to 2022-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Normalize composer file
-        if: matrix.normalize == true && matrix.php !== '8.0'
+        if: matrix.normalize == true && matrix.php != '8.0'
         run: composer normalize --dry-run
 
       - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Normalize composer file
-        if: matrix.normalize == true
+        if: matrix.normalize == true && matrix.php !== '8.0'
         run: composer normalize --dry-run
 
       - name: Run test suite

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -164,7 +164,7 @@ return [
     |
     */
 
-    'api_version' => env('SHOPIFY_API_VERSION', '2021-01'),
+    'api_version' => env('SHOPIFY_API_VERSION', '2022-01'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -42,7 +42,7 @@ class ApiHelperTest extends TestCase
         $this->assertInstanceOf(BasicShopifyAPI::class, $api);
         $this->assertSame(Util::getShopifyConfig('api_secret'), $this->app['config']->get('shopify-app.api_secret'));
         $this->assertSame(Util::getShopifyConfig('api_key'), $this->app['config']->get('shopify-app.api_key'));
-        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2021-01');
+        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2022-01');
     }
 
     public function testSetAndGetApi(): void


### PR DESCRIPTION
This updates the default API version to be `2022-01` because `2021-01` is no longer supported.

It will flag up deprecation an error for apps like so: 

![image](https://user-images.githubusercontent.com/32519106/149789961-5101dbe5-3702-4492-814e-c22f4898425c.png)
