### PR TITLE
Fixed app-bridge redirect on fullpage_redirect auth view

### DIFF
--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -58,8 +58,12 @@ trait AuthController
             return View::make(
                 'shopify-app::auth.fullpage_redirect',
                 [
+                    'apiKey' => Util::getShopifyConfig('api_key', $shopDomain ?? $request->user()->name ),
+                    'appBridgeVersion' => Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '',
                     'authUrl' => $result['url'],
+                    'host' => $request->host,
                     'shopDomain' => $shopDomain->toNative(),
+                    'shopOrigin' => $shopDomain ?? $request->user()->name,
                 ]
             );
         } else {

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -58,7 +58,7 @@ trait AuthController
             return View::make(
                 'shopify-app::auth.fullpage_redirect',
                 [
-                    'apiKey' => Util::getShopifyConfig('api_key', $shopDomain ?? $request->user()->name ),
+                    'apiKey' => Util::getShopifyConfig('api_key', $shopDomain ?? $request->user()->name),
                     'appBridgeVersion' => Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '',
                     'authUrl' => $result['url'],
                     'host' => $request->host,

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -55,15 +55,18 @@ trait AuthController
                 throw new MissingAuthUrlException('Missing auth url');
             }
 
+            $shopDomain = $shopDomain->toNative();
+            $shopOrigin = $shopDomain ?? $request->user()->name;
+
             return View::make(
                 'shopify-app::auth.fullpage_redirect',
                 [
-                    'apiKey' => Util::getShopifyConfig('api_key', $shopDomain ?? $request->user()->name),
+                    'apiKey' => Util::getShopifyConfig('api_key', $shopOrigin),
                     'appBridgeVersion' => Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '',
                     'authUrl' => $result['url'],
-                    'host' => $request->host,
-                    'shopDomain' => $shopDomain->toNative(),
-                    'shopOrigin' => $shopDomain ?? $request->user()->name,
+                    'host' => $request->host ?? base64_encode($shopOrigin.'/admin'),
+                    'shopDomain' => $shopDomain,
+                    'shopOrigin' => $shopOrigin,
                 ]
             );
         } else {

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -6,6 +6,8 @@
 
         <title>Redirecting...</title>
 
+        <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";
@@ -17,11 +19,17 @@
                     normalizedLink = document.createElement('a');
                     normalizedLink.href = redirectUrl;
 
-                    data = JSON.stringify({
-                        message: 'Shopify.API.remoteRedirect',
-                        data: { location: redirectUrl },
+                    var AppBridge = window['app-bridge'];
+                    var createApp = AppBridge.default;
+                    var Redirect = AppBridge.actions.Redirect;
+                    var app = createApp({
+                        apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
+                        shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
+                        host: "{{ \Request::get('host') }}",
                     });
-                    window.parent.postMessage(data, "https://{{ $shopDomain }}");
+
+                    var redirect = Redirect.create(app);
+                    redirect.dispatch(Redirect.Action.REMOTE, normalizedLink.href);
                 }
             });
         </script>

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -6,8 +6,8 @@
 
         <title>Redirecting...</title>
 
-        <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
-        <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script src="https://unpkg.com/@shopify/app-bridge{!! $appBridgeVersion !!}"></script>
+        <script src="https://unpkg.com/@shopify/app-bridge-utils{!! $appBridgeVersion !!}"></script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";
@@ -23,9 +23,9 @@
                     var createApp = AppBridge.default;
                     var Redirect = AppBridge.actions.Redirect;
                     var app = createApp({
-                        apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
-                        shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
-                        host: "{{ \Request::get('host') }}",
+                        apiKey: "{{!! $apiKey !!}}",
+                        shopOrigin: "{{!! $shopOrigin !!}}",
+                        host: "{{!! $host !!}}",
                     });
 
                     var redirect = Redirect.create(app);


### PR DESCRIPTION
## Summary

Shopify is deprecating EASDK and the package was making making an EASDK calls (ie `Shopify.API.remoteRedirect`). This triggered the message for the apps consuming the library.

> Closes #1094

## What was done?

This PR refactors the EASDK call to redirect the app made on the `auth/fullpage_redirect.blade.php` view to use App Bridge instead.