### PR TITLE
Added the support for AWS EventBridge Shopify Webhook

### DIFF
--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -366,26 +366,44 @@ class ApiHelper implements IApiHelper
      */
     public function createWebhook(array $payload): ResponseAccess
     {
-        $query = '
-        mutation webhookSubscriptionCreate(
-            $topic: WebhookSubscriptionTopic!,
-            $webhookSubscription: WebhookSubscriptionInput!
-        ) {
-            webhookSubscriptionCreate(
-                topic: $topic
-                webhookSubscription: $webhookSubscription
-            ) {
-                userErrors {
-                    field
+
+        $address_type = Util::getShopifyConfig('webhook_address_type');
+        if($address_type === "arn"){
+            $query = '
+            mutation eventBridgeWebhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: EventBridgeWebhookSubscriptionInput!) {
+                eventBridgeWebhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
+                  userErrors {
                     message
-                }
-                webhookSubscription {
+                  }
+                  webhookSubscription {
                     id
                     topic
+                  }
+                }
+              }
+              ';
+        }else{
+            $query = '
+            mutation webhookSubscriptionCreate(
+                $topic: WebhookSubscriptionTopic!,
+                $webhookSubscription: WebhookSubscriptionInput!
+            ) {
+                webhookSubscriptionCreate(
+                    topic: $topic
+                    webhookSubscription: $webhookSubscription
+                ) {
+                    userErrors {
+                        field
+                        message
+                    }
+                    webhookSubscription {
+                        id
+                        topic
+                    }
                 }
             }
+            ';
         }
-        ';
 
         // Change REST-format topics ("resource/event")
         // to GraphQL-format topics ("RESOURCE_EVENT"), for pre-v17 compatibility
@@ -393,13 +411,12 @@ class ApiHelper implements IApiHelper
         $variables = [
             'topic' => $topic,
             'webhookSubscription' => [
-                'callbackUrl' => $payload['address'],
+                $address_type => $payload['address'],
                 'format' => 'JSON',
             ],
         ];
 
         $response = $this->doRequestGraphQL($query, $variables);
-
         return $response['body'];
     }
 

--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -366,13 +366,13 @@ class ApiHelper implements IApiHelper
      */
     public function createWebhook(array $payload): ResponseAccess
     {
-
-        $address_type = Util::getShopifyConfig('webhook_address_type');
-        if($address_type === "arn"){
+        $addressType = Util::getShopifyConfig('webhook_address_type');
+        if($addressType === "arn"){
             $query = '
             mutation eventBridgeWebhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: EventBridgeWebhookSubscriptionInput!) {
                 eventBridgeWebhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
                   userErrors {
+                    field
                     message
                   }
                   webhookSubscription {
@@ -411,12 +411,13 @@ class ApiHelper implements IApiHelper
         $variables = [
             'topic' => $topic,
             'webhookSubscription' => [
-                $address_type => $payload['address'],
+                $addressType => $payload['address'],
                 'format' => 'JSON',
             ],
         ];
 
         $response = $this->doRequestGraphQL($query, $variables);
+
         return $response['body'];
     }
 

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -328,6 +328,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Shopify Webhooks Address Type
+    |--------------------------------------------------------------------------
+    |
+    | This option is for defining webhooks type.
+    | `callbackUrl` it's use https:// route.
+    | `arn` it's use arn route.
+    |
+    | This documentation will helps you
+    | https://shopify.dev/apps/webhooks/configuration/eventbridge
+    |
+    */
+    
+    'webhook_address_type' => env('SHOPIFY_WEBHOOK_ADDRESS_TYPE', 'arn'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Shopify Webhooks
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
There is support for webhookSubscriptionCreate. I check in osiste/Laravel Package and there is no support for eventBridgeWebhookSubscriptionCreate GraphQL.

So I have added the support for eventBridgeWebhookSubscriptionCreate

Issue: https://github.com/osiset/laravel-shopify/issues/1113