### PR TITLE
Feature | Add Session Refresh Time to ENV

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -470,5 +470,7 @@ return [
         * The table name for Plan model.
         */
         'plans' => 'plans',
-    ]
+    ],
+
+    'session_token_refresh_interval' => env('SESSION_TOKEN_REFRESH_INTERVAL', 2000)
 ];

--- a/src/resources/views/partials/token_handler.blade.php
+++ b/src/resources/views/partials/token_handler.blade.php
@@ -1,9 +1,9 @@
 <script data-turbolinks-eval="false">
-    var SESSION_TOKEN_REFRESH_INTERVAL = 2000;
+    var SESSION_TOKEN_REFRESH_INTERVAL = {{ \Osiset\ShopifyApp\Util::getShopifyConfig('session_token_refresh_interval') ?? 2000 }};
     var LOAD_EVENT = '{{ \Osiset\ShopifyApp\Util::getShopifyConfig('turbo_enabled') ? 'turbolinks:load' : 'DOMContentLoaded' }}';
 
     // Token updates
-    document.addEventListener(LOAD_EVENT, (event) => {
+    document.addEventListener(LOAD_EVENT, () => {
         retrieveToken(app);
         keepRetrievingToken(app);
     });

--- a/src/resources/views/partials/token_handler.blade.php
+++ b/src/resources/views/partials/token_handler.blade.php
@@ -1,5 +1,5 @@
 <script data-turbolinks-eval="false">
-    var SESSION_TOKEN_REFRESH_INTERVAL = {{ \Osiset\ShopifyApp\Util::getShopifyConfig('session_token_refresh_interval') ?? 2000 }};
+    var SESSION_TOKEN_REFRESH_INTERVAL = {{ \Osiset\ShopifyApp\Util::getShopifyConfig('session_token_refresh_interval') }};
     var LOAD_EVENT = '{{ \Osiset\ShopifyApp\Util::getShopifyConfig('turbo_enabled') ? 'turbolinks:load' : 'DOMContentLoaded' }}';
 
     // Token updates


### PR DESCRIPTION
This PR adds the refresh token interval found in `token.blade` to the config so that the default time of 2 seconds can be changed by the user.

This helps #1116 and #1076 