### PR TITLE
Fix when we try to reauth scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache
+/.idea

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -22,9 +22,9 @@ trait AuthController
     /**
      * Installing/authenticating a shop.
      *
+     * @return ViewView|RedirectResponse
      * @throws MissingShopDomainException if both shop parameter and authenticated user are missing
      *
-     * @return ViewView|RedirectResponse
      */
     public function authenticate(Request $request, AuthenticateShop $authShop)
     {
@@ -54,8 +54,15 @@ trait AuthController
                 throw new MissingAuthUrlException('Missing auth url');
             }
 
-            // Just return them straight to the OAUTH flow.
-            return Redirect::to($result['url']);
+            // If we need to reauth this needs to be the parent
+            return View::make(
+                'shopify-app::auth.fullpage_redirect',
+                [
+                    'authUrl' => $result['url'],
+                    'shopDomain' => $shopDomain->toNative(),
+                ]
+            );
+
         } else {
             // Go to home route
             return Redirect::route(
@@ -87,10 +94,10 @@ trait AuthController
             $params['shop'] = $params['shop'] ?? $shopDomain->toNative() ?? '';
             unset($params['token']);
 
-            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
+            $cleanTarget = trim(explode('?', $target)[0] . '?' . http_build_query($params), '?');
         } else {
             $params = ['shop' => $shopDomain->toNative() ?? ''];
-            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
+            $cleanTarget = trim(explode('?', $target)[0] . '?' . http_build_query($params), '?');
         }
 
         return View::make(

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -22,9 +22,9 @@ trait AuthController
     /**
      * Installing/authenticating a shop.
      *
-     * @return ViewView|RedirectResponse
      * @throws MissingShopDomainException if both shop parameter and authenticated user are missing
      *
+     * @return ViewView|RedirectResponse
      */
     public function authenticate(Request $request, AuthenticateShop $authShop)
     {
@@ -62,7 +62,6 @@ trait AuthController
                     'shopDomain' => $shopDomain->toNative(),
                 ]
             );
-
         } else {
             // Go to home route
             return Redirect::route(
@@ -94,10 +93,10 @@ trait AuthController
             $params['shop'] = $params['shop'] ?? $shopDomain->toNative() ?? '';
             unset($params['token']);
 
-            $cleanTarget = trim(explode('?', $target)[0] . '?' . http_build_query($params), '?');
+            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
         } else {
             $params = ['shop' => $shopDomain->toNative() ?? ''];
-            $cleanTarget = trim(explode('?', $target)[0] . '?' . http_build_query($params), '?');
+            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
         }
 
         return View::make(

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -5,23 +5,26 @@
         <base target="_top">
 
         <title>Redirecting...</title>
-
+        <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";
-                if (window.top == window.self) {
+                if (window.top === window.self) {
                     // If the current window is the 'parent', change the URL by setting location.href
-                    window.top.location.href = redirectUrl;
+                    window.location.assign(redirectUrl)
                 } else {
                     // If the current window is the 'child', change the parent's URL with postMessage
-                    normalizedLink = document.createElement('a');
-                    normalizedLink.href = redirectUrl;
 
-                    data = JSON.stringify({
-                        message: 'Shopify.API.remoteRedirect',
-                        data: { location: redirectUrl },
+                    var AppBridge = window['app-bridge'];
+                    var actions = AppBridge.actions;
+                    var createApp = AppBridge.default;
+                    var Redirect = actions.Redirect;
+                    var app = createApp({
+                        apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
+                        host: "{{ \Request::get('host') }}",
                     });
-                    window.parent.postMessage(data, "https://{{ $shopDomain }}");
+                    Redirect.create(app).dispatch(Redirect.Action.REMOTE, redirectUrl);
                 }
             });
         </script>

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -23,9 +23,12 @@ class AuthControllerTest extends TestCase
         // Run the request
         $response = $this->call('post', '/authenticate', ['shop' => 'example.myshopify.com']);
 
-        // Check the redirect happens and location is set properly in the header.
-        $response->assertStatus(302);
-        $response->assertHeader('location', 'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate');
+        // Check the view
+        $response->assertViewHas('shopDomain', 'example.myshopify.com');
+        $response->assertViewHas(
+            'authUrl',
+            'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate'
+        );
     }
 
     public function testAuthAcceptsShopWithCode(): void


### PR DESCRIPTION
This PR brings back the full page reauth because when you update the api scopes after install you will run into the iframe error as it is set to deny.