### PR TITLE
Verify theme support

### DIFF
--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -4,8 +4,8 @@ namespace Osiset\ShopifyApp\Actions;
 
 use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Util;
 
 /**
  * Authenticates a shop and fires post authentication actions.
@@ -114,9 +114,10 @@ class AuthenticateShop
         // Fire the post processing jobs
         $themeSupportLevel = call_user_func($this->verifyThemeSupport, $result['shop_id']);
 
-        if ($themeSupportLevel == ThemeSupportLevel::UNSUPPORTED) {
+        if (in_array($themeSupportLevel, Util::getShopifyConfig('theme_support.unacceptable_levels'))) {
             call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
         }
+
         call_user_func($this->dispatchWebhooksAction, $result['shop_id'], false);
         call_user_func($this->afterAuthorizeAction, $result['shop_id']);
 

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Actions;
 
 use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 
 /**
@@ -24,6 +25,13 @@ class AuthenticateShop
      * @var InstallShop
      */
     protected $installShopAction;
+
+    /**
+     * The action for verify theme support
+     *
+     * @var VerifyThemeSupport
+     */
+    protected $verifyThemeSupport;
 
     /**
      * The action for dispatching scripts.
@@ -49,23 +57,26 @@ class AuthenticateShop
     /**
      * Setup.
      *
-     * @param IApiHelper       $apiHelper              The API helper.
-     * @param InstallShop      $installShopAction      The action for installing a shop.
-     * @param DispatchScripts  $dispatchScriptsAction  The action for dispatching scripts.
-     * @param DispatchWebhooks $dispatchWebhooksAction The action for dispatching webhooks.
-     * @param AfterAuthorize   $afterAuthorizeAction   The action for after authorize actions.
+     * @param IApiHelper            $apiHelper              The API helper.
+     * @param InstallShop           $installShopAction      The action for installing a shop.
+     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
+     * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
+     * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
+     * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
      *
      * @return void
      */
     public function __construct(
         IApiHelper $apiHelper,
         InstallShop $installShopAction,
+        VerifyThemeSupport $verifyThemeSupport,
         DispatchScripts $dispatchScriptsAction,
         DispatchWebhooks $dispatchWebhooksAction,
         AfterAuthorize $afterAuthorizeAction
     ) {
         $this->apiHelper = $apiHelper;
         $this->installShopAction = $installShopAction;
+        $this->verifyThemeSupport = $verifyThemeSupport;
         $this->dispatchScriptsAction = $dispatchScriptsAction;
         $this->dispatchWebhooksAction = $dispatchWebhooksAction;
         $this->afterAuthorizeAction = $afterAuthorizeAction;
@@ -101,7 +112,11 @@ class AuthenticateShop
         }
 
         // Fire the post processing jobs
-        call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        $themeSupportLevel = call_user_func($this->verifyThemeSupport, $result['shop_id']);
+
+        if ($themeSupportLevel == ThemeSupportLevel::UNSUPPORTED) {
+            call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        }
         call_user_func($this->dispatchWebhooksAction, $result['shop_id'], false);
         call_user_func($this->afterAuthorizeAction, $result['shop_id']);
 

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -32,8 +32,18 @@ class VerifyThemeSupport
      */
     const ASSET_FIELD = 'key';
 
+    /**
+     * Interval for caching the request: minutes, seconds, hours, days, etc.
+     *
+     * @var string
+     */
     protected $cacheInterval;
 
+    /**
+     * Cache duration
+     *
+     * @var int
+     */
     protected $cacheDuration;
 
     /**
@@ -110,7 +120,7 @@ class VerifyThemeSupport
 
         return match (true) {
             $hasTemplates && $allTemplatesHasRightType => ThemeSupportLevel::FULL,
-            $templatesСountWithRightType => ThemeSupportLevel::PARTIAL,
+            (bool) $templatesСountWithRightType => ThemeSupportLevel::PARTIAL,
             default => ThemeSupportLevel::UNSUPPORTED,
         };
     }

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Osiset\ShopifyApp\Actions;
+
+use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Util;
+use Illuminate\Support\Facades\Cache;
+use Osiset\ShopifyApp\Contracts\ShopModel;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
+
+/**
+ * Activates a plan for a shop.
+ */
+class VerifyThemeSupport
+{
+    /**
+     * Main theme role
+     */
+    const MAIN_ROLE = 'main';
+
+    /**
+     * Theme field
+     */
+    const THEME_FIELD = 'role';
+
+    /**
+     * Asset field
+     */
+    const ASSET_FIELD = 'key';
+
+    protected $cacheInterval;
+
+    protected $cacheDuration;
+
+    /**
+     * Shop main theme
+     *
+     * @var MainTheme
+     */
+    protected $mainTheme;
+
+    /**
+     * Theme assets
+     *
+     */
+    protected $assets;
+
+    /**
+     * Querier for shops.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
+
+    /**
+     * Command for shops.
+     *
+     * @var IShopCommand
+     */
+    protected $shopCommand;
+
+    /**
+     * Setup.
+     *
+     * @param IShopQuery     $shopQuery               The querier for shops.
+     * @param IShopCommand   $shopCommand             The commands for shops.
+     *
+     * @return void
+     */
+    public function __construct(
+        IShopQuery $shopQuery,
+        IShopCommand $shopCommand
+    ) {
+        $this->shopQuery = $shopQuery;
+        $this->shopCommand = $shopCommand;
+
+        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
+            ->plural()
+            ->ucfirst()
+            ->start('add')
+            ->__toString();
+        $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
+    }
+
+    /**
+     * Execution.
+     *
+     * @param ShopId $shopId The shop ID.
+     *
+     * @return ThemeSupport
+     */
+    public function __invoke(ShopId $shopId)
+    {
+        $shop = $this->shopQuery->getById($shopId);
+
+        $this->mainTheme = $this->extractStoreMainTheme($shop);
+        $this->assets = $this->extractThemeAssets($shop);
+
+        $templateJSONFiles = $this->templateJSONFiles();
+        $templateMainSections = $this->mainSections($shop, $templateJSONFiles);
+        $sectionsWithAppBlock = $this->sectionsWithAppBlock($shop, $templateMainSections);
+
+        $hasTemplates = count($templateJSONFiles) > 0;
+        $allTemplatesHasRightType = count($templateJSONFiles) === count($sectionsWithAppBlock);
+        $templatesСountWithRightType = count($sectionsWithAppBlock);
+
+        return match (true) {
+            $hasTemplates && $allTemplatesHasRightType => ThemeSupportLevel::FULL,
+            $templatesСountWithRightType => ThemeSupportLevel::PARTIAL,
+            default => ThemeSupportLevel::UNSUPPORTED,
+        };
+    }
+
+    /**
+     * Extract store main theme
+     *
+     * @param ShopModel $shop
+     *
+     * @return MainTheme
+     */
+    private function extractStoreMainTheme(ShopModel $shop): MainTheme
+    {
+        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
+
+        $themes = $themesResponse['body']['themes']->toArray();
+        $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
+
+        return MainTheme::fromNative($themes[$key]);
+    }
+
+    /**
+     * Extract main theme assets
+     *
+     * @param ShopModel $shop
+     *
+     * @return array
+     */
+    private function extractThemeAssets(ShopModel $shop): array
+    {
+        return Cache::remember(
+            "assets_{$this->mainTheme->getId()->toNative()}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            fn () => $shop->api()->rest(
+                'GET',
+                "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
+            )['body']['assets']->toArray()
+        );
+    }
+
+    /**
+     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
+     *
+     * @return array
+     */
+    private function templateJSONFiles(): array
+    {
+        return array_filter($this->assets, function ($asset) {
+            $match = false;
+            $blockTemplates = Util::getShopifyConfig('theme_support.templates');
+
+            foreach ($blockTemplates as $template) {
+                if ($asset['key'] == "templates/$template.json") {
+                    $match = true;
+                    break;
+                }
+            }
+
+            return $match;
+        });
+    }
+
+    /**
+     * Retrieve the body of JSON templates and find what section is set as `main`
+     *
+     * @param ShopModel $shop
+     * @param array $templateJSONFiles
+     *
+     * @return array
+     */
+    private function mainSections(ShopModel $shop, array $templateJSONFiles): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+            $assetValue = json_decode($asset['value'], true);
+
+            $mainAsset = array_filter($assetValue['sections'], function ($value, $key) {
+                return $key == self::MAIN_ROLE || str_starts_with($value['type'], self::MAIN_ROLE);
+            }, ARRAY_FILTER_USE_BOTH);
+
+            if ($mainAsset) {
+                return array_merge(...array_filter($this->assets, function ($asset) use ($mainAsset) {
+                    return $asset['key'] === 'sections/' . end($mainAsset)['type'] . '.liquid';
+                }));
+            }
+        }, $templateJSONFiles));
+    }
+
+    /**
+     * Request the content of each section and check if it has a schema that contains a block of type '@app'
+     *
+     * @param ShopModel $shop
+     * @param array $templateMainSections
+     *
+     * @return array
+     */
+    private function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $acceptsAppBlock = false;
+
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+
+            preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
+            $schema = json_decode($matches[1], true);
+
+            if ($schema && isset($schema['blocks'])) {
+                $acceptsAppBlock = in_array('@app', array_column($schema['blocks'], 'type'));
+            }
+
+            return $acceptsAppBlock ? $file : null;
+        }, $templateMainSections));
+    }
+
+    /**
+     * Fetch asset
+     *
+     * @param ShopModel $shop
+     * @param array $file
+     *
+     * @return array
+     */
+    private function fetchAsset(ShopModel $shop, array $file): array
+    {
+        return Cache::remember(
+            "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            fn () => $shop->api()->rest(
+                'GET',
+                "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
+                [
+                    'asset' => [ 'key' => $file['key'] ]
+                ]
+            )
+        );
+    }
+}

--- a/src/Contracts/Objects/Values/ThemeId.php
+++ b/src/Contracts/Objects/Values/ThemeId.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's ID value object.
+ */
+interface ThemeId extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeName.php
+++ b/src/Contracts/Objects/Values/ThemeName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's name value object.
+ */
+interface ThemeName extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeRole.php
+++ b/src/Contracts/Objects/Values/ThemeRole.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's role value object.
+ */
+interface ThemeRole extends ValueObject
+{
+}

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -31,5 +31,5 @@ class ThemeSupportLevel implements ValueObject
      *
      * @var int
      */
-    public const UNSUPPORTED = 2;
+    public const UNSUPPORTED = 3;
 }

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Online Store 2.0 theme support
+ */
+class ThemeSupportLevel implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Support level: fully.
+     *
+     * @var int
+     */
+    public const FULL = 1;
+
+    /**
+     * Support level: partial.
+     *
+     * @var int
+     */
+    public const PARTIAL = 2;
+
+    /**
+     * Support level: unsupported.
+     *
+     * @var int
+     */
+    public const UNSUPPORTED = 2;
+}

--- a/src/Objects/Values/MainTheme.php
+++ b/src/Objects/Values/MainTheme.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\CompositeTrait;
+use Funeralzone\ValueObjects\ValueObject;
+use Illuminate\Support\Arr;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Used to inject current session data into the user's model.
+ * TODO: Possibly move this to a composite VO?
+ */
+final class MainTheme implements ValueObject
+{
+    use CompositeTrait;
+
+    /**
+     * Theme id
+     *
+     * @var ThemeId
+     */
+    protected $id;
+
+    /**
+     * Theme name
+     *
+     * @var ThemeName
+     */
+    protected $name;
+
+    /**
+     * Theme role
+     *
+     * @var ThemeRole
+     */
+    protected $role;
+
+    /**
+     * __construct
+     *
+     * @param ThemeIdValue $id
+     * @param ThemeNameValue $name
+     * @param ThemeRoleValue $role
+     */
+    public function __construct(ThemeIdValue $id, ThemeNameValue $name, ThemeRoleValue $role)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->role = $role;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromNative($native)
+    {
+        return new static(
+            NullableThemeId::fromNative(Arr::get($native, 'id')),
+            NullableThemeName::fromNative(Arr::get($native, 'name')),
+            NullableThemeRole::fromNative(Arr::get($native, 'role'))
+        );
+    }
+
+    /**
+     * Get theme id
+     *
+     * @return  ThemeId
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get theme name
+     *
+     * @return  ThemeName
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get theme role
+     *
+     * @return  ThemeRole
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+}

--- a/src/Objects/Values/NullThemeId.php
+++ b/src/Objects/Values/NullThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (null).
+ */
+final class NullThemeId implements ThemeIdValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeName.php
+++ b/src/Objects/Values/NullThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (null).
+ */
+final class NullThemeName implements ThemeNameValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeRole.php
+++ b/src/Objects/Values/NullThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (null).
+ */
+final class NullThemeRole implements ThemeRoleValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullableThemeId.php
+++ b/src/Objects/Values/NullableThemeId.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (nullable).
+ */
+final class NullableThemeId extends Nullable implements ThemeIdValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeId::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeId::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeName.php
+++ b/src/Objects/Values/NullableThemeName.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (nullable).
+ */
+final class NullableThemeName extends Nullable implements ThemeNameValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeName::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeName::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeRole.php
+++ b/src/Objects/Values/NullableThemeRole.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (nullable).
+ */
+final class NullableThemeRole extends Nullable implements ThemeRoleValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeRole::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeRole::class;
+    }
+}

--- a/src/Objects/Values/ThemeId.php
+++ b/src/Objects/Values/ThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\IntegerTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID.
+ */
+final class ThemeId implements ThemeIdValue
+{
+    use IntegerTrait;
+}

--- a/src/Objects/Values/ThemeName.php
+++ b/src/Objects/Values/ThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name.
+ */
+final class ThemeName implements ThemeNameValue
+{
+    use StringTrait;
+}

--- a/src/Objects/Values/ThemeRole.php
+++ b/src/Objects/Values/ThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role.
+ */
+final class ThemeRole implements ThemeRoleValue
+{
+    use StringTrait;
+}

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -19,6 +19,7 @@ use Osiset\ShopifyApp\Actions\DispatchScripts as DispatchScriptsAction;
 use Osiset\ShopifyApp\Actions\DispatchWebhooks as DispatchWebhooksAction;
 use Osiset\ShopifyApp\Actions\GetPlanUrl as GetPlanUrlAction;
 use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
+use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;
@@ -119,6 +120,7 @@ class ShopifyAppProvider extends ServiceProvider
             return new AuthenticateShopAction(
                 $app->make(IApiHelper::class),
                 $app->make(InstallShopAction::class),
+                $app->make(VerifyThemeSupportAction::class),
                 $app->make(DispatchScriptsAction::class),
                 $app->make(DispatchWebhooksAction::class),
                 $app->make(AfterAuthorizeAction::class)
@@ -166,6 +168,13 @@ class ShopifyAppProvider extends ServiceProvider
                 $app->make(IShopQuery::class),
                 $app->make(IPlanQuery::class),
                 $app->make(IChargeCommand::class),
+                $app->make(IShopCommand::class)
+            );
+        });
+
+        $this->app->bind(VerifyThemeSupportAction::class, function ($app) {
+            return new VerifyThemeSupportAction(
+                $app->make(IShopQuery::class),
                 $app->make(IShopCommand::class)
             );
         });

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -197,7 +197,7 @@ return [
     |
     */
 
-    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products'),
+    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products,read_theme'),
 
     /*
     |--------------------------------------------------------------------------
@@ -470,5 +470,28 @@ return [
         * The table name for Plan model.
         */
         'plans' => 'plans',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Checking theme compatibility
+    |--------------------------------------------------------------------------
+    |
+    | It is necessary to check if your application is compatible with the theme app blocks.
+    |
+    */
+    'theme_support' => [
+        /**
+         * Specify the name of the template the app will integrate with
+         */
+        'templates' => ['product', 'collection', 'index'],
+        /**
+         * Interval for caching the request: minutes, seconds, hours, days, etc.
+         */
+        'cache_interval' => 'hours',
+        /**
+         * Cache duration
+         */
+        'cache_duration' => '12'
     ]
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -197,7 +197,7 @@ return [
     |
     */
 
-    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products,read_theme'),
+    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products,read_themes'),
 
     /*
     |--------------------------------------------------------------------------
@@ -492,6 +492,14 @@ return [
         /**
          * Cache duration
          */
-        'cache_duration' => '12'
+        'cache_duration' => '12',
+         /**
+         * At which levels of theme support the use of "theme app extension" is not available
+         * and script tags will be installed.
+         * Available levels: FULL, PARTIAL, UNSUPPORTED.
+         */
+        'unacceptable_levels' => [
+            Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED
+        ]
     ]
 ];


### PR DESCRIPTION
As you know lately, Shopify does not allow applications that only use script tags. 

To work with the Online Store 2.0 you need to use "Theme app extensions".
But in this case you should not install script tags.
If the store has not yet updated the theme and is using the Online Store 1.0, script tags must be installed.

These changes solve this problem