### PR TITLE
Propose to fix Billable app throwing exception on install

### DIFF
--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -27,18 +27,18 @@ trait BillingController
     /**
      * Redirects to billing screen for Shopify.
      *
-     * @param int|null    $plan        The plan's ID, if provided in route.
      * @param Request     $request     The request object.
      * @param ShopQuery    $shopQuery    The shop querier.
      * @param GetPlanUrl  $getPlanUrl  The action for getting the plan URL.
+     * @param int|null    $plan        The plan's ID, if provided in route.
      *
      * @return ViewView
      */
     public function index(
-        ?int $plan = null,
         Request $request,
         ShopQuery $shopQuery,
-        GetPlanUrl $getPlanUrl
+        GetPlanUrl $getPlanUrl,
+        ?int $plan = null
     ): ViewView {
         // Get the shop
         $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));


### PR DESCRIPTION
Fix PHP 8.0: Deprecate required parameters after optional parameters in function/method signatures