### PR TITLE
Verify shopify with SPA

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -101,6 +101,14 @@ class VerifyShopify
             return $next($request);
         }
 
+        if (Util::getShopifyConfig('spa_frontend_used')) {
+            $storeResult = $this->checkPreviousInstallation($request);
+
+            if ($storeResult) {
+                return $next($request);
+            }
+        }
+
         $tokenSource = $this->getAccessTokenFromRequest($request);
         if ($tokenSource === null) {
             //Check if there is a store record in the database

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -102,7 +102,7 @@ class VerifyShopify
         }
 
         if (Util::getShopifyConfig('spa_frontend_used')) {
-            $storeResult = $this->checkPreviousInstallation($request);
+            $storeResult = !$this->isApiRequest($request) && $this->checkPreviousInstallation($request);
 
             if ($storeResult) {
                 return $next($request);
@@ -110,6 +110,7 @@ class VerifyShopify
         }
 
         $tokenSource = $this->getAccessTokenFromRequest($request);
+
         if ($tokenSource === null) {
             //Check if there is a store record in the database
             return $this->checkPreviousInstallation($request)

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -101,7 +101,7 @@ class VerifyShopify
             return $next($request);
         }
 
-        if (Util::getShopifyConfig('spa_frontend_used')) {
+        if (!Util::useNativeAppBridge()) {
             $storeResult = !$this->isApiRequest($request) && $this->checkPreviousInstallation($request);
 
             if ($storeResult) {

--- a/src/Objects/Enums/FrontendEngine.php
+++ b/src/Objects/Enums/FrontendEngine.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Online Store 2.0 theme support
+ */
+class FrontendEngine implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Laravel Blade
+     *
+     * @var int
+     */
+    public const BLADE = 0;
+
+    /**
+     * Vue.js
+     *
+     * @var int
+     */
+    public const VUE = 1;
+
+    /**
+     * React
+     *
+     * @var int
+     */
+    public const REACT = 2;
+}

--- a/src/Services/CookieHelper.php
+++ b/src/Services/CookieHelper.php
@@ -47,11 +47,11 @@ class CookieHelper
      */
     public function setCookiePolicy(): void
     {
-        Config::set('session.expire_on_close', true);
+        $this->app['config']->set('session.expire_on_close', true);
 
         if ($this->checkSameSiteNoneCompatible()) {
-            Config::set('session.secure', true);
-            Config::set('session.same_site', 'none');
+            $this->app['config']->set('session.secure', true);
+            $this->app['config']->set('session.same_site', 'none');
         }
     }
 

--- a/src/Services/CookieHelper.php
+++ b/src/Services/CookieHelper.php
@@ -47,11 +47,11 @@ class CookieHelper
      */
     public function setCookiePolicy(): void
     {
-        $this->app['config']->set('session.expire_on_close', true);
+        Config::set('session.expire_on_close', true);
 
         if ($this->checkSameSiteNoneCompatible()) {
-            $this->app['config']->set('session.secure', true);
-            $this->app['config']->set('session.same_site', 'none');
+            Config::set('session.secure', true);
+            Config::set('session.same_site', 'none');
         }
     }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -239,10 +239,11 @@ class Util
      */
     public static function useNativeAppBridge(): bool
     {
-        $currentFrontendEngine = FrontendEngine::fromNative(
+        $frontendEngine = FrontendEngine::fromNative(
             self::getShopifyConfig('frontend_engine') ?? 'BLADE'
         );
+        $reactEngine = FrontendEngine::fromNative('REACT');
 
-        return !$currentFrontendEngine->isSame(FrontendEngine::REACT());
+        return !$frontendEngine->isSame($reactEngine);
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -241,12 +241,6 @@ class Util
     {
         $currentFrontendEngine = self::getShopifyConfig('frontend_engine') ?? FrontendEngine::BLADE;
 
-        switch ($currentFrontendEngine) {
-            case FrontendEngine::REACT:
-                return false;
-
-            default:
-                return true;
-        }
+        return !$currentFrontendEngine->isSame(FrontendEngine::REACT);
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -239,8 +239,8 @@ class Util
      */
     public static function useNativeAppBridge(): bool
     {
-        $currentFrontendEngine = self::getShopifyConfig('frontend_engine') ?? FrontendEngine::BLADE;
+        $currentFrontendEngine = self::getShopifyConfig('frontend_engine') ?? FrontendEngine::BLADE();
 
-        return !$currentFrontendEngine->isSame(FrontendEngine::REACT);
+        return !$currentFrontendEngine->isSame(FrontendEngine::REACT());
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use LogicException;
-use Osiset\ShopifyApp\Objects\Values\Hmac;
 use Osiset\ShopifyApp\Objects\Enums\FrontendEngine;
+use Osiset\ShopifyApp\Objects\Values\Hmac;
 
 /**
  * Utilities and helpers used in various parts of the package.
@@ -235,7 +235,7 @@ class Util
     /**
      * Checking to see if you need to use the native App Bridge
      *
-     * @return boolean
+     * @return bool
      */
     public static function useNativeAppBridge(): bool
     {

--- a/src/Util.php
+++ b/src/Util.php
@@ -239,7 +239,9 @@ class Util
      */
     public static function useNativeAppBridge(): bool
     {
-        $currentFrontendEngine = self::getShopifyConfig('frontend_engine') ?? FrontendEngine::BLADE();
+        $currentFrontendEngine = FrontendEngine::fromNative(
+            self::getShopifyConfig('frontend_engine') ?? 'BLADE'
+        );
 
         return !$currentFrontendEngine->isSame(FrontendEngine::REACT());
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use LogicException;
 use Osiset\ShopifyApp\Objects\Values\Hmac;
+use Osiset\ShopifyApp\Objects\Enums\FrontendEngine;
 
 /**
  * Utilities and helpers used in various parts of the package.
@@ -229,5 +230,23 @@ class Util
     public static function getShopsTableForeignKey(): string
     {
         return Str::singular(self::getShopsTable()).'_id';
+    }
+
+    /**
+     * Checking to see if you need to use the native App Bridge
+     *
+     * @return boolean
+     */
+    public static function useNativeAppBridge(): bool
+    {
+        $currentFrontendEngine = self::getShopifyConfig('frontend_engine') ?? FrontendEngine::BLADE;
+
+        switch ($currentFrontendEngine) {
+            case FrontendEngine::REACT:
+                return false;
+
+            default:
+                return true;
+        }
     }
 }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -490,5 +490,5 @@ return [
     | No changes are made for Vue.js and Blade.
     |
     */
-    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE
+    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE,
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -484,11 +484,10 @@ return [
     | Frontend engine used
     |--------------------------------------------------------------------------
     |
-    | Available engines: BLADE, VUE, REACT.
+    | Available engines: "BLADE", "VUE", or "REACT".
     | For example, if you use React, you do not need to be redirected to a separate page to get the JWT token.
-    |
     | No changes are made for Vue.js and Blade.
     |
     */
-    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE(),
+    'frontend_engine' => env('SHOPIFY_FRONTEND_ENGINE', 'BLADE'),
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -470,5 +470,15 @@ return [
         * The table name for Plan model.
         */
         'plans' => 'plans',
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Determines whether the SPA is used
+    |--------------------------------------------------------------------------
+    |
+    | If you use SPA (React or Vue), you don't need a redirect to the JWT token retrieval page
+    |
+    */
+    'spa_frontend_used' => (bool) env('SHOPIFY_SPA_FRONTEND_USED', false),
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -477,15 +477,18 @@ return [
         'shops' => 'users',
     ],
 
+    'session_token_refresh_interval' => env('SESSION_TOKEN_REFRESH_INTERVAL', 2000),
+
     /*
     |--------------------------------------------------------------------------
-    | Determines whether the SPA is used
+    | Frontend engine used
     |--------------------------------------------------------------------------
     |
-    | If you use SPA (React or Vue), you don't need a redirect to the JWT token retrieval page
+    | Available engines: BLADE, VUE, REACT.
+    | For example, if you use React, you do not need to be redirected to a separate page to get the JWT token.
+    |
+    | No changes are made for Vue.js and Blade.
     |
     */
-    'spa_frontend_used' => (bool) env('SHOPIFY_SPA_FRONTEND_USED', false),,
-
-    'session_token_refresh_interval' => env('SESSION_TOKEN_REFRESH_INTERVAL', 2000),
+    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -490,5 +490,5 @@ return [
     | No changes are made for Vue.js and Blade.
     |
     */
-    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE,
+    'frontend_engine' => \Osiset\ShopifyApp\Objects\Enums\FrontendEngine::BLADE(),
 ];

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -17,7 +17,7 @@
             </div>
         </div>
 
-        @if(\Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_enabled') && !\Osiset\ShopifyApp\Util::getShopifyConfig('spa_frontend_used'))
+        @if(\Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_enabled') && \Osiset\ShopifyApp\Util::useNativeAppBridge())
             <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -17,7 +17,7 @@
             </div>
         </div>
 
-        @if(\Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_enabled'))
+        @if(\Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_enabled') && !\Osiset\ShopifyApp\Util::getShopifyConfig('spa_frontend_used'))
             <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Test;
 
 use Illuminate\Support\Facades\Config;
 use LogicException;
+use Osiset\ShopifyApp\Objects\Enums\FrontendEngine;
 use Osiset\ShopifyApp\Util;
 use stdClass;
 
@@ -104,5 +105,23 @@ class UtilTest extends TestCase
             'ORDERS_PARTIALLY_FULFILLED',
             Util::getGraphQLWebhookTopic('ORDERS_PARTIALLY_FULFILLED')
         );
+    }
+
+    public function testUseNativeAppBridgeIsTrue(): void
+    {
+        Config::set('shopify-app.frontend_engine', FrontendEngine::VUE);
+
+        $result = Util::useNativeAppBridge();
+
+        $this->assertTrue($result);
+    }
+
+    public function testUseNativeAppBridgeIsFalse(): void
+    {
+        Config::set('shopify-app.frontend_engine', FrontendEngine::REACT);
+
+        $result = Util::useNativeAppBridge();
+
+        $this->assertFalse($result);
     }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -109,7 +109,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsTrue(): void
     {
-        Config::set('shopify-app.frontend_engine', FrontendEngine::VUE);
+        Config::set('shopify-app.frontend_engine', FrontendEngine::VUE());
 
         $result = Util::useNativeAppBridge();
 
@@ -118,7 +118,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsFalse(): void
     {
-        Config::set('shopify-app.frontend_engine', FrontendEngine::REACT);
+        Config::set('shopify-app.frontend_engine', FrontendEngine::REACT());
 
         $result = Util::useNativeAppBridge();
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,7 +4,6 @@ namespace Osiset\ShopifyApp\Test;
 
 use Illuminate\Support\Facades\Config;
 use LogicException;
-use Osiset\ShopifyApp\Objects\Enums\FrontendEngine;
 use Osiset\ShopifyApp\Util;
 use stdClass;
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -69,7 +69,7 @@ class UtilTest extends TestCase
 
     public function testGetShopifyConfig(): void
     {
-        Config::set('shopify-app.config_api_callback', function (string $key, $shop) {
+        $this->app['config']->set('shopify-app.config_api_callback', function (string $key, $shop) {
             if ($key === 'api_secret') {
                 return 'hello world';
             }
@@ -109,7 +109,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsTrue(): void
     {
-        Config::set('shopify-app.frontend_engine', FrontendEngine::VUE());
+        $this->app['config']->set('shopify-app.frontend_engine', FrontendEngine::VUE());
 
         $result = Util::useNativeAppBridge();
 
@@ -118,7 +118,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsFalse(): void
     {
-        Config::set('shopify-app.frontend_engine', FrontendEngine::REACT());
+        $this->app['config']->set('shopify-app.frontend_engine', FrontendEngine::REACT());
 
         $result = Util::useNativeAppBridge();
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -109,7 +109,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsTrue(): void
     {
-        $this->app['config']->set('shopify-app.frontend_engine', FrontendEngine::VUE());
+        $this->app['config']->set('shopify-app.frontend_engine', 'VUE');
 
         $result = Util::useNativeAppBridge();
 
@@ -118,7 +118,7 @@ class UtilTest extends TestCase
 
     public function testUseNativeAppBridgeIsFalse(): void
     {
-        $this->app['config']->set('shopify-app.frontend_engine', FrontendEngine::REACT());
+        $this->app['config']->set('shopify-app.frontend_engine', 'REACT');
 
         $result = Util::useNativeAppBridge();
 


### PR DESCRIPTION
If you have a SPA frontend (React, Vue, or something else), there is no point in redirecting to the "authenticate.token" route.

Redirecting and then getting the token has the following disadvantages:
1) it takes longer to load the application;
2) the token is added to url as a get parameter.

This PR adds validation:
if you specified in the settings that you are using SPA, a record is created in the table "users" and this user is not deleted, then the request is skipped.

Then you just need to describe the logic in your frontend.

Example for React:

```javascript
import React from 'react';
import ReactDOM from 'react-dom/client';
import '@shopify/polaris/build/esm/styles.css';
import {AppProvider, Page, Card} from '@shopify/polaris';
import { Provider } from '@shopify/app-bridge-react';
import { AppRoutes } from './AppRoutes';

const root = ReactDOM.createRoot(document.getElementById('root'));

const host = new URLSearchParams(location.search).get("host");
const apiKey = process.env.MIX_SHOPIFY_API_KEY;

const config = { apiKey, host, forceRedirect: true };

root.render(
    <Provider config={config}>
        <AppProvider i18n={{  }}>
            <Page title="Example app">
                <Card sectioned>
                    <AppRoutes />
                </Card>
            </Page>
        </AppProvider>
    </Provider>
  );
```


