### PR TITLE
Setting up Iframe protection

### DIFF
--- a/src/Http/Middleware/IframeProtection.php
+++ b/src/Http/Middleware/IframeProtection.php
@@ -5,8 +5,8 @@ namespace Osiset\ShopifyApp\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 
 /**
  * Responsibility for protection against clickjaking
@@ -46,7 +46,7 @@ class IframeProtection
         $response = $next($request);
 
         $shop = Cache::remember(
-            'frame-ancestors_' . $request->get('shop'),
+            'frame-ancestors_'.$request->get('shop'),
             now()->addMinutes(20),
             function () use ($request) {
                 return $this->shopQuery->getByDomain(ShopDomain::fromRequest($request));

--- a/src/Http/Middleware/IframeProtection.php
+++ b/src/Http/Middleware/IframeProtection.php
@@ -48,7 +48,9 @@ class IframeProtection
         $shop = Cache::remember(
             'frame-ancestors_' . $request->get('shop'),
             now()->addMinutes(20),
-            fn () => $this->shopQuery->getByDomain(ShopDomain::fromRequest($request))
+            function () use ($request) {
+                return $this->shopQuery->getByDomain(ShopDomain::fromRequest($request));
+            }
         );
 
         $domain = $shop

--- a/src/Http/Middleware/IframeProtection.php
+++ b/src/Http/Middleware/IframeProtection.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Osiset\ShopifyApp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+
+/**
+ * Responsibility for protection against clickjaking
+ */
+class IframeProtection
+{
+    /**
+     * The shop querier.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
+
+    /**
+     * Constructor.
+     *
+     * @param IShopQuery  $shopQuery The shop querier.
+     *
+     * @return void
+     */
+    public function __construct(
+        IShopQuery $shopQuery
+    ) {
+        $this->shopQuery = $shopQuery;
+    }
+
+    /**
+     * Set frame-ancestors header
+     *
+     * @param Request  $request The request object.
+     * @param \Closure $next    The next action.
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $shop = Cache::remember(
+            'frame-ancestors_' . $request->get('shop'),
+            now()->addMinutes(20),
+            fn () => $this->shopQuery->getByDomain(ShopDomain::fromRequest($request))
+        );
+
+        $domain = $shop
+            ? $shop->name
+            : '*.myshopify.com';
+
+        $response->headers->set(
+            'Content-Security-Policy',
+            "frame-ancestors https://$domain https://admin.shopify.com"
+        );
+
+        return $response;
+    }
+}

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -30,6 +30,7 @@ use Osiset\ShopifyApp\Directives\SessionToken;
 use Osiset\ShopifyApp\Http\Middleware\AuthProxy;
 use Osiset\ShopifyApp\Http\Middleware\AuthWebhook;
 use Osiset\ShopifyApp\Http\Middleware\Billable;
+use Osiset\ShopifyApp\Http\Middleware\IframeProtection;
 use Osiset\ShopifyApp\Http\Middleware\VerifyShopify;
 use Osiset\ShopifyApp\Macros\TokenRedirect;
 use Osiset\ShopifyApp\Macros\TokenRoute;
@@ -305,6 +306,8 @@ class ShopifyAppProvider extends ServiceProvider
         $this->app['router']->aliasMiddleware('auth.webhook', AuthWebhook::class);
         $this->app['router']->aliasMiddleware('billable', Billable::class);
         $this->app['router']->aliasMiddleware('verify.shopify', VerifyShopify::class);
+
+        $this->app['router']->pushMiddlewareToGroup('web', IframeProtection::class);
     }
 
     /**

--- a/tests/Http/Middleware/IframeProtectionTest.php
+++ b/tests/Http/Middleware/IframeProtectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Http\Middleware;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use Osiset\ShopifyApp\Http\Middleware\IframeProtection;
+use Osiset\ShopifyApp\Storage\Queries\Shop as ShopQuery;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class IframeProtectionTest extends TestCase
+{
+    /**
+     * @var AuthManager
+     */
+    protected $auth;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auth = $this->app->make(AuthManager::class);
+    }
+
+    public function testIframeProtectionWithAuthorizedShop(): void
+    {
+        $shop = factory($this->model)->create();
+        $this->auth->login($shop);
+
+        $domain = auth()->user()->name;
+        $header = "frame-ancestors https://$domain https://admin.shopify.com";
+
+        Http::fake([
+            route('home') => Http::response([], 200, [
+                'Content-Security-Policy' => "frame-ancestors https://$domain https://admin.shopify.com",
+            ]),
+        ]);
+
+        $response = Http::get(route('home'));
+
+        $this->assertNotEmpty($response->getHeader('content-security-policy'));
+        $this->assertEquals("frame-ancestors https://$domain https://admin.shopify.com", $header);
+    }
+
+    public function testIframeProtectionWithUnauthorizedShop(): void
+    {
+        $request = new Request();
+        $next = function () {
+            return new Response('Test Response');
+        };
+
+        $middleware = new IframeProtection(new ShopQuery());
+        $response = $middleware->handle($request, $next);
+
+        $header = $response->headers->get('content-security-policy');
+
+        $this->assertNotEmpty($header);
+        $this->assertEquals('frame-ancestors https://*.myshopify.com https://admin.shopify.com', $header);
+    }
+}

--- a/tests/Http/Middleware/IframeProtectionTest.php
+++ b/tests/Http/Middleware/IframeProtectionTest.php
@@ -5,11 +5,9 @@ namespace Osiset\ShopifyApp\Test\Http\Middleware;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Http;
 use Osiset\ShopifyApp\Http\Middleware\IframeProtection;
 use Osiset\ShopifyApp\Storage\Queries\Shop as ShopQuery;
 use Osiset\ShopifyApp\Test\TestCase;
-use Osiset\ShopifyApp\Util;
 
 class IframeProtectionTest extends TestCase
 {


### PR DESCRIPTION
At the moment, if you do not set some of the headers, the application will not pass the review.

This header (frame-ancestors) allows you to open the application in an iframe only from an allowed domain