### PR TITLE
Allow ergebnis/composer-normalize to run the code clean on workflows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,10 @@
         "phpunit/phpunit": "~8.0 || ^9.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
`ergebnis/composer-normalize` is being stopped by composer to normalize because it is not an allowed plugin and this is killing the tests in the workflows.