### PR TITLE
Verify theme support level

### DIFF
--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Actions;
 use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Util;
 
 /**
  * Authenticates a shop and fires post authentication actions.
@@ -49,11 +50,11 @@ class AuthenticateShop
     /**
      * Setup.
      *
-     * @param IApiHelper       $apiHelper              The API helper.
-     * @param InstallShop      $installShopAction      The action for installing a shop.
-     * @param DispatchScripts  $dispatchScriptsAction  The action for dispatching scripts.
-     * @param DispatchWebhooks $dispatchWebhooksAction The action for dispatching webhooks.
-     * @param AfterAuthorize   $afterAuthorizeAction   The action for after authorize actions.
+     * @param IApiHelper            $apiHelper              The API helper.
+     * @param InstallShop           $installShopAction      The action for installing a shop.
+     * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
+     * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
+     * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
      *
      * @return void
      */
@@ -101,7 +102,10 @@ class AuthenticateShop
         }
 
         // Fire the post processing jobs
-        call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {
+            call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        }
+
         call_user_func($this->dispatchWebhooksAction, $result['shop_id'], false);
         call_user_func($this->afterAuthorizeAction, $result['shop_id']);
 

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -52,6 +52,7 @@ class AuthenticateShop
      *
      * @param IApiHelper            $apiHelper              The API helper.
      * @param InstallShop           $installShopAction      The action for installing a shop.
+     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
      * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
      * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
      * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
@@ -61,12 +62,14 @@ class AuthenticateShop
     public function __construct(
         IApiHelper $apiHelper,
         InstallShop $installShopAction,
+        VerifyThemeSupport $verifyThemeSupport,
         DispatchScripts $dispatchScriptsAction,
         DispatchWebhooks $dispatchWebhooksAction,
         AfterAuthorize $afterAuthorizeAction
     ) {
         $this->apiHelper = $apiHelper;
         $this->installShopAction = $installShopAction;
+        $this->verifyThemeSupport = $verifyThemeSupport;
         $this->dispatchScriptsAction = $dispatchScriptsAction;
         $this->dispatchWebhooksAction = $dispatchWebhooksAction;
         $this->afterAuthorizeAction = $afterAuthorizeAction;
@@ -100,6 +103,8 @@ class AuthenticateShop
             // Throw exception, something is wrong
             return [$result, null];
         }
+
+        dd($result);
 
         // Fire the post processing jobs
         if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -104,8 +104,6 @@ class AuthenticateShop
             return [$result, null];
         }
 
-        dd($result);
-
         // Fire the post processing jobs
         if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {
             call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -9,6 +9,7 @@ use Osiset\ShopifyApp\Objects\Enums\AuthMode;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel;
 use Osiset\ShopifyApp\Util;
 
 /**
@@ -31,18 +32,28 @@ class InstallShop
     protected $shopCommand;
 
     /**
+     * The action for verify theme support
+     *
+     * @var VerifyThemeSupport
+     */
+    protected $verifyThemeSupport;
+
+    /**
      * Setup.
      *
      * @param IShopQuery  $shopQuery   The querier for the shop.
+     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
      *
      * @return void
      */
     public function __construct(
         IShopQuery $shopQuery,
-        IShopCommand $shopCommand
+        IShopCommand $shopCommand,
+        VerifyThemeSupport $verifyThemeSupport,
     ) {
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;
+        $this->verifyThemeSupport = $verifyThemeSupport;
     }
 
     /**
@@ -57,6 +68,7 @@ class InstallShop
     {
         // Get the shop
         $shop = $this->shopQuery->getByDomain($shopDomain, [], true);
+
         if ($shop === null) {
             // Shop does not exist, make them and re-get
             $this->shopCommand->make($shopDomain, NullAccessToken::fromNative(null));
@@ -88,10 +100,14 @@ class InstallShop
             $data = $apiHelper->getAccessData($code);
             $this->shopCommand->setAccessToken($shop->getId(), AccessToken::fromNative($data['access_token']));
 
+            $themeSupportLevel = call_user_func($this->verifyThemeSupport, $shop->getId());
+            $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevel::fromNative($themeSupportLevel));
+
             return [
                 'completed' => true,
                 'url' => null,
                 'shop_id' => $shop->getId(),
+                'theme_support_level' => $themeSupportLevel,
             ];
         } catch (Exception $e) {
             // Just return the default setting
@@ -99,6 +115,7 @@ class InstallShop
                 'completed' => false,
                 'url' => null,
                 'shop_id' => null,
+                'theme_support_level' => null,
             ];
         }
     }

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Osiset\ShopifyApp\Actions;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Contracts\ShopModel;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Util;
+
+/**
+ * Activates a plan for a shop.
+ */
+class VerifyThemeSupport
+{
+    /**
+     * Main theme role
+     */
+    public const MAIN_ROLE = 'main';
+
+    /**
+     * Theme field
+     */
+    public const THEME_FIELD = 'role';
+
+    /**
+     * Asset field
+     */
+    public const ASSET_FIELD = 'key';
+
+    /**
+     * Interval for caching the request: minutes, seconds, hours, days, etc.
+     *
+     * @var string
+     */
+    protected $cacheInterval;
+
+    /**
+     * Cache duration
+     *
+     * @var int
+     */
+    protected $cacheDuration;
+
+    /**
+     * Shop main theme
+     *
+     * @var MainTheme
+     */
+    protected $mainTheme;
+
+    /**
+     * Theme assets
+     */
+    protected $assets;
+
+    /**
+     * Querier for shops.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
+
+    /**
+     * Command for shops.
+     *
+     * @var IShopCommand
+     */
+    protected $shopCommand;
+
+    /**
+     * Setup.
+     *
+     * @param IShopQuery     $shopQuery               The querier for shops.
+     * @param IShopCommand   $shopCommand             The commands for shops.
+     *
+     * @return void
+     */
+    public function __construct(
+        IShopQuery $shopQuery,
+        IShopCommand $shopCommand
+    ) {
+        $this->shopQuery = $shopQuery;
+        $this->shopCommand = $shopCommand;
+
+        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
+            ->plural()
+            ->ucfirst()
+            ->start('add')
+            ->__toString();
+        $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
+    }
+
+    /**
+     * Execution.
+     *
+     * @param ShopId $shopId The shop ID.
+     *
+     * @return int
+     */
+    public function __invoke(ShopId $shopId): int
+    {
+        $shop = $this->shopQuery->getById($shopId);
+
+        $this->mainTheme = $this->extractStoreMainTheme($shop);
+
+        if ($this->mainTheme->getId()->toNative()) {
+            $this->assets = $this->extractThemeAssets($shop);
+
+            $templateJSONFiles = $this->templateJSONFiles();
+            $templateMainSections = $this->mainSections($shop, $templateJSONFiles);
+            $sectionsWithAppBlock = $this->sectionsWithAppBlock($shop, $templateMainSections);
+
+            $hasTemplates = count($templateJSONFiles) > 0;
+            $allTemplatesHasRightType = count($templateJSONFiles) === count($sectionsWithAppBlock);
+            $templatesСountWithRightType = count($sectionsWithAppBlock);
+
+            switch (true) {
+                case $hasTemplates && $allTemplatesHasRightType:
+                    return ThemeSupportLevel::FULL;
+
+                case $templatesСountWithRightType:
+                    return ThemeSupportLevel::PARTIAL;
+
+                default:
+                    return ThemeSupportLevel::UNSUPPORTED;
+            }
+        }
+
+        return ThemeSupportLevel::UNSUPPORTED;
+    }
+
+    /**
+     * Extract store main theme
+     *
+     * @param ShopModel $shop
+     *
+     * @return MainTheme
+     */
+    private function extractStoreMainTheme(ShopModel $shop): MainTheme
+    {
+        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
+
+        if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
+            $themes = $themesResponse['body']['themes']->toArray();
+            $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
+
+            return MainTheme::fromNative($themes[$key]);
+        }
+
+        return MainTheme::fromNative([]);
+    }
+
+    /**
+     * Extract main theme assets
+     *
+     * @param ShopModel $shop
+     *
+     * @return array
+     */
+    private function extractThemeAssets(ShopModel $shop): array
+    {
+        return Cache::remember(
+            "assets_{$this->mainTheme->getId()->toNative()}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
+                )['body']['assets']->toArray();
+            }
+        );
+    }
+
+    /**
+     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
+     *
+     * @return array
+     */
+    private function templateJSONFiles(): array
+    {
+        return array_filter($this->assets, function ($asset) {
+            $match = false;
+            $blockTemplates = Util::getShopifyConfig('theme_support.templates');
+
+            foreach ($blockTemplates as $template) {
+                if ($asset['key'] == "templates/$template.json") {
+                    $match = true;
+
+                    break;
+                }
+            }
+
+            return $match;
+        });
+    }
+
+    /**
+     * Retrieve the body of JSON templates and find what section is set as `main`
+     *
+     * @param ShopModel $shop
+     * @param array $templateJSONFiles
+     *
+     * @return array
+     */
+    private function mainSections(ShopModel $shop, array $templateJSONFiles): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+            $assetValue = json_decode($asset['value'], true);
+
+            $mainAsset = array_filter($assetValue['sections'], function ($value, $key) {
+                return $key == self::MAIN_ROLE || str_starts_with($value['type'], self::MAIN_ROLE);
+            }, ARRAY_FILTER_USE_BOTH);
+
+            if ($mainAsset) {
+                return array_merge(...array_filter($this->assets, function ($asset) use ($mainAsset) {
+                    return $asset['key'] === 'sections/'.end($mainAsset)['type'].'.liquid';
+                }));
+            }
+        }, $templateJSONFiles));
+    }
+
+    /**
+     * Request the content of each section and check if it has a schema that contains a block of type '@app'
+     *
+     * @param ShopModel $shop
+     * @param array $templateMainSections
+     *
+     * @return array
+     */
+    private function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $acceptsAppBlock = false;
+
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+
+            preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
+            $schema = json_decode($matches[1], true);
+
+            if ($schema && isset($schema['blocks'])) {
+                $acceptsAppBlock = in_array('@app', array_column($schema['blocks'], 'type'));
+            }
+
+            return $acceptsAppBlock ? $file : null;
+        }, $templateMainSections));
+    }
+
+    /**
+     * Fetch asset
+     *
+     * @param ShopModel $shop
+     * @param array $file
+     *
+     * @return array
+     */
+    private function fetchAsset(ShopModel $shop, array $file): array
+    {
+        return Cache::remember(
+            "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop, $file) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
+                    [
+                        'asset' => ['key' => $file['key']],
+                    ]
+                );
+            }
+        );
+    }
+}

--- a/src/Contracts/Commands/Shop.php
+++ b/src/Contracts/Commands/Shop.php
@@ -6,6 +6,7 @@ use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken as AccessTokenValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\PlanId as PlanIdValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopId as ShopIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
 
 /**
  * Represents commands for shops.
@@ -41,6 +42,16 @@ interface Shop
      * @return bool
      */
     public function setAccessToken(ShopIdValue $shopId, AccessTokenValue $token): bool;
+
+    /**
+     * Sets the Online Store 2.0 support level
+     *
+     * @param ShopIdValue       $shopId The shop's ID.
+     * @param ThemeSupportLevel $themeSupportLevel  Support level
+     *
+     * @return bool
+     */
+    public function setThemeSupportLevel(ShopIdValue $shopId, ThemeSupportLevelValue $themeSupportLevel): bool;
 
     /**
      * Cleans the shop's properties (token, plan).

--- a/src/Contracts/Objects/Values/ThemeId.php
+++ b/src/Contracts/Objects/Values/ThemeId.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's ID value object.
+ */
+interface ThemeId extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeName.php
+++ b/src/Contracts/Objects/Values/ThemeName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's name value object.
+ */
+interface ThemeName extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeRole.php
+++ b/src/Contracts/Objects/Values/ThemeRole.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's role value object.
+ */
+interface ThemeRole extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeSupportLevel.php
+++ b/src/Contracts/Objects/Values/ThemeSupportLevel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Access token value object.
+ */
+interface ThemeSupportLevel extends ValueObject
+{
+}

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Online Store 2.0 theme support
+ */
+class ThemeSupportLevel implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Support level: fully.
+     *
+     * @var int
+     */
+    public const FULL = 0;
+
+    /**
+     * Support level: partial.
+     *
+     * @var int
+     */
+    public const PARTIAL = 1;
+
+    /**
+     * Support level: unsupported.
+     *
+     * @var int
+     */
+    public const UNSUPPORTED = 2;
+}

--- a/src/Objects/Values/MainTheme.php
+++ b/src/Objects/Values/MainTheme.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\CompositeTrait;
+use Funeralzone\ValueObjects\ValueObject;
+use Illuminate\Support\Arr;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Used to inject current session data into the user's model.
+ * TODO: Possibly move this to a composite VO?
+ */
+final class MainTheme implements ValueObject
+{
+    use CompositeTrait;
+
+    /**
+     * Theme id
+     *
+     * @var ThemeId
+     */
+    protected $id;
+
+    /**
+     * Theme name
+     *
+     * @var ThemeName
+     */
+    protected $name;
+
+    /**
+     * Theme role
+     *
+     * @var ThemeRole
+     */
+    protected $role;
+
+    /**
+     * __construct
+     *
+     * @param ThemeIdValue $id
+     * @param ThemeNameValue $name
+     * @param ThemeRoleValue $role
+     */
+    public function __construct(ThemeIdValue $id, ThemeNameValue $name, ThemeRoleValue $role)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->role = $role;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromNative($native)
+    {
+        return new static(
+            NullableThemeId::fromNative(Arr::get($native, 'id')),
+            NullableThemeName::fromNative(Arr::get($native, 'name')),
+            NullableThemeRole::fromNative(Arr::get($native, 'role'))
+        );
+    }
+
+    /**
+     * Get theme id
+     *
+     * @return  ThemeId
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get theme name
+     *
+     * @return  ThemeName
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get theme role
+     *
+     * @return  ThemeRole
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+}

--- a/src/Objects/Values/NullThemeId.php
+++ b/src/Objects/Values/NullThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (null).
+ */
+final class NullThemeId implements ThemeIdValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeName.php
+++ b/src/Objects/Values/NullThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (null).
+ */
+final class NullThemeName implements ThemeNameValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeRole.php
+++ b/src/Objects/Values/NullThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (null).
+ */
+final class NullThemeRole implements ThemeRoleValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullableThemeId.php
+++ b/src/Objects/Values/NullableThemeId.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (nullable).
+ */
+final class NullableThemeId extends Nullable implements ThemeIdValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeId::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeId::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeName.php
+++ b/src/Objects/Values/NullableThemeName.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (nullable).
+ */
+final class NullableThemeName extends Nullable implements ThemeNameValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeName::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeName::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeRole.php
+++ b/src/Objects/Values/NullableThemeRole.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (nullable).
+ */
+final class NullableThemeRole extends Nullable implements ThemeRoleValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeRole::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeRole::class;
+    }
+}

--- a/src/Objects/Values/ThemeId.php
+++ b/src/Objects/Values/ThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\IntegerTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID.
+ */
+final class ThemeId implements ThemeIdValue
+{
+    use IntegerTrait;
+}

--- a/src/Objects/Values/ThemeName.php
+++ b/src/Objects/Values/ThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name.
+ */
+final class ThemeName implements ThemeNameValue
+{
+    use StringTrait;
+}

--- a/src/Objects/Values/ThemeRole.php
+++ b/src/Objects/Values/ThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role.
+ */
+final class ThemeRole implements ThemeRoleValue
+{
+    use StringTrait;
+}

--- a/src/Objects/Values/ThemeSupportLevel.php
+++ b/src/Objects/Values/ThemeSupportLevel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\IntegerTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
+
+/**
+ * Value object for shop's ID.
+ */
+final class ThemeSupportLevel implements ThemeSupportLevelValue
+{
+    use IntegerTrait;
+}

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -19,6 +19,7 @@ use Osiset\ShopifyApp\Actions\DispatchScripts as DispatchScriptsAction;
 use Osiset\ShopifyApp\Actions\DispatchWebhooks as DispatchWebhooksAction;
 use Osiset\ShopifyApp\Actions\GetPlanUrl as GetPlanUrlAction;
 use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
+use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;
@@ -120,6 +121,7 @@ class ShopifyAppProvider extends ServiceProvider
             return new AuthenticateShopAction(
                 $app->make(IApiHelper::class),
                 $app->make(InstallShopAction::class),
+                $app->make(VerifyThemeSupportAction::class),
                 $app->make(DispatchScriptsAction::class),
                 $app->make(DispatchWebhooksAction::class),
                 $app->make(AfterAuthorizeAction::class)
@@ -167,6 +169,13 @@ class ShopifyAppProvider extends ServiceProvider
                 $app->make(IShopQuery::class),
                 $app->make(IPlanQuery::class),
                 $app->make(IChargeCommand::class),
+                $app->make(IShopCommand::class)
+            );
+        });
+
+        $this->app->bind(VerifyThemeSupportAction::class, function ($app) {
+            return new VerifyThemeSupportAction(
+                $app->make(IShopQuery::class),
                 $app->make(IShopCommand::class)
             );
         });

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -113,7 +113,8 @@ class ShopifyAppProvider extends ServiceProvider
         $this->app->bind(InstallShopAction::class, function ($app) {
             return new InstallShopAction(
                 $app->make(IShopQuery::class),
-                $app->make(IShopCommand::class)
+                $app->make(IShopCommand::class),
+                $app->make(VerifyThemeSupportAction::class),
             );
         });
 

--- a/src/Storage/Commands/Shop.php
+++ b/src/Storage/Commands/Shop.php
@@ -8,6 +8,7 @@ use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken as AccessTokenValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\PlanId as PlanIdValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopId as ShopIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as ShopQuery;
 use Osiset\ShopifyApp\Contracts\ShopModel;
 use Osiset\ShopifyApp\Util;
@@ -75,6 +76,17 @@ class Shop implements ShopCommand
         $shop = $this->getShop($shopId);
         $shop->password = $token->toNative();
         $shop->password_updated_at = Carbon::now();
+
+        return $shop->save();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setThemeSupportLevel(ShopIdValue $shopId, ThemeSupportLevelValue $themeSupportLevel): bool
+    {
+        $shop = $this->getShop($shopId);
+        $shop->theme_support_level = $themeSupportLevel->toNative();
 
         return $shop->save();
     }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -197,7 +197,7 @@ return [
     |
     */
 
-    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products'),
+    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products,read_themes'),
 
     /*
     |--------------------------------------------------------------------------
@@ -470,5 +470,36 @@ return [
         * The table name for Plan model.
         */
         'plans' => 'plans',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Checking theme compatibility
+    |--------------------------------------------------------------------------
+    |
+    | It is necessary to check if your application is compatible with the theme app blocks.
+    |
+    */
+    'theme_support' => [
+        /**
+         * Specify the name of the template the app will integrate with
+         */
+        'templates' => ['product', 'collection', 'index'],
+        /**
+         * Interval for caching the request: minutes, seconds, hours, days, etc.
+         */
+        'cache_interval' => 'hours',
+        /**
+         * Cache duration
+         */
+        'cache_duration' => '12',
+         /**
+         * At which levels of theme support the use of "theme app extension" is not available
+         * and script tags will be installed.
+         * Available levels: FULL, PARTIAL, UNSUPPORTED.
+         */
+        'unacceptable_levels' => [
+            Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED
+        ]
     ]
 ];

--- a/src/resources/database/migrations/2022_06_09_104819_add_theme_support_level_to_users_table.php
+++ b/src/resources/database/migrations/2022_06_09_104819_add_theme_support_level_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddThemeSupportLevelToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('theme_support_level')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('theme_support_level');
+        });
+    }
+}

--- a/tests/Actions/InstallShopTest.php
+++ b/tests/Actions/InstallShopTest.php
@@ -31,7 +31,7 @@ class InstallShopTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
+            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
             $result['url']
         );
         $this->assertFalse($result['completed']);
@@ -50,7 +50,7 @@ class InstallShopTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
+            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
             $result['url']
         );
         $this->assertFalse($result['completed']);

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -27,7 +27,7 @@ class AuthControllerTest extends TestCase
         $response->assertViewHas('shopDomain', 'example.myshopify.com');
         $response->assertViewHas(
             'authUrl',
-            'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate'
+            'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate'
         );
     }
 


### PR DESCRIPTION
As you know lately, Shopify does not allow applications that only use script tags.

To work with the Online Store 2.0 you need to use "Theme app extensions".
But in this case you should not install script tags.
If the store has not yet updated the theme and is using the Online Store 1.0, script tags must be installed.

These changes solve this problem