### PR TITLE
Verify theme support

### DIFF
--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Actions;
 use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Util;
 
 /**
  * Authenticates a shop and fires post authentication actions.
@@ -49,11 +50,11 @@ class AuthenticateShop
     /**
      * Setup.
      *
-     * @param IApiHelper       $apiHelper              The API helper.
-     * @param InstallShop      $installShopAction      The action for installing a shop.
-     * @param DispatchScripts  $dispatchScriptsAction  The action for dispatching scripts.
-     * @param DispatchWebhooks $dispatchWebhooksAction The action for dispatching webhooks.
-     * @param AfterAuthorize   $afterAuthorizeAction   The action for after authorize actions.
+     * @param IApiHelper            $apiHelper              The API helper.
+     * @param InstallShop           $installShopAction      The action for installing a shop.
+     * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
+     * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
+     * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
      *
      * @return void
      */
@@ -101,7 +102,10 @@ class AuthenticateShop
         }
 
         // Fire the post processing jobs
-        call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {
+            call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);
+        }
+
         call_user_func($this->dispatchWebhooksAction, $result['shop_id'], false);
         call_user_func($this->afterAuthorizeAction, $result['shop_id']);
 

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -27,13 +27,6 @@ class AuthenticateShop
     protected $installShopAction;
 
     /**
-     * The action for determine the level of support for extensions.
-     *
-     * @var VerifyThemeSupport
-     */
-    protected $verifyThemeSupport;
-
-    /**
      * The action for dispatching scripts.
      *
      * @var DispatchScripts
@@ -59,7 +52,6 @@ class AuthenticateShop
      *
      * @param IApiHelper            $apiHelper              The API helper.
      * @param InstallShop           $installShopAction      The action for installing a shop.
-     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
      * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
      * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
      * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
@@ -69,14 +61,12 @@ class AuthenticateShop
     public function __construct(
         IApiHelper $apiHelper,
         InstallShop $installShopAction,
-        VerifyThemeSupport $verifyThemeSupport,
         DispatchScripts $dispatchScriptsAction,
         DispatchWebhooks $dispatchWebhooksAction,
         AfterAuthorize $afterAuthorizeAction
     ) {
         $this->apiHelper = $apiHelper;
         $this->installShopAction = $installShopAction;
-        $this->verifyThemeSupport = $verifyThemeSupport;
         $this->dispatchScriptsAction = $dispatchScriptsAction;
         $this->dispatchWebhooksAction = $dispatchWebhooksAction;
         $this->afterAuthorizeAction = $afterAuthorizeAction;

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -52,6 +52,7 @@ class AuthenticateShop
      *
      * @param IApiHelper            $apiHelper              The API helper.
      * @param InstallShop           $installShopAction      The action for installing a shop.
+     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
      * @param DispatchScripts       $dispatchScriptsAction  The action for dispatching scripts.
      * @param DispatchWebhooks      $dispatchWebhooksAction The action for dispatching webhooks.
      * @param AfterAuthorize        $afterAuthorizeAction   The action for after authorize actions.
@@ -61,12 +62,14 @@ class AuthenticateShop
     public function __construct(
         IApiHelper $apiHelper,
         InstallShop $installShopAction,
+        VerifyThemeSupport $verifyThemeSupport,
         DispatchScripts $dispatchScriptsAction,
         DispatchWebhooks $dispatchWebhooksAction,
         AfterAuthorize $afterAuthorizeAction
     ) {
         $this->apiHelper = $apiHelper;
         $this->installShopAction = $installShopAction;
+        $this->verifyThemeSupport = $verifyThemeSupport;
         $this->dispatchScriptsAction = $dispatchScriptsAction;
         $this->dispatchWebhooksAction = $dispatchWebhooksAction;
         $this->afterAuthorizeAction = $afterAuthorizeAction;
@@ -100,6 +103,8 @@ class AuthenticateShop
             // Throw exception, something is wrong
             return [$result, null];
         }
+
+        dd($result);
 
         // Fire the post processing jobs
         if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -27,6 +27,13 @@ class AuthenticateShop
     protected $installShopAction;
 
     /**
+     * The action for determine the level of support for extensions.
+     *
+     * @var VerifyThemeSupport
+     */
+    protected $verifyThemeSupport;
+
+    /**
      * The action for dispatching scripts.
      *
      * @var DispatchScripts

--- a/src/Actions/AuthenticateShop.php
+++ b/src/Actions/AuthenticateShop.php
@@ -104,8 +104,6 @@ class AuthenticateShop
             return [$result, null];
         }
 
-        dd($result);
-
         // Fire the post processing jobs
         if (in_array($result['theme_support_level'], Util::getShopifyConfig('theme_support.unacceptable_levels'))) {
             call_user_func($this->dispatchScriptsAction, $result['shop_id'], false);

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -9,6 +9,7 @@ use Osiset\ShopifyApp\Objects\Enums\AuthMode;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
+use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel;
 use Osiset\ShopifyApp\Util;
 
 /**
@@ -31,18 +32,28 @@ class InstallShop
     protected $shopCommand;
 
     /**
+     * The action for verify theme support
+     *
+     * @var VerifyThemeSupport
+     */
+    protected $verifyThemeSupport;
+
+    /**
      * Setup.
      *
      * @param IShopQuery  $shopQuery   The querier for the shop.
+     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
      *
      * @return void
      */
     public function __construct(
         IShopQuery $shopQuery,
-        IShopCommand $shopCommand
+        IShopCommand $shopCommand,
+        VerifyThemeSupport $verifyThemeSupport,
     ) {
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;
+        $this->verifyThemeSupport = $verifyThemeSupport;
     }
 
     /**
@@ -57,6 +68,7 @@ class InstallShop
     {
         // Get the shop
         $shop = $this->shopQuery->getByDomain($shopDomain, [], true);
+
         if ($shop === null) {
             // Shop does not exist, make them and re-get
             $this->shopCommand->make($shopDomain, NullAccessToken::fromNative(null));
@@ -88,10 +100,14 @@ class InstallShop
             $data = $apiHelper->getAccessData($code);
             $this->shopCommand->setAccessToken($shop->getId(), AccessToken::fromNative($data['access_token']));
 
+            $themeSupportLevel = call_user_func($this->verifyThemeSupport, $shop->getId());
+            $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevel::fromNative($themeSupportLevel));
+
             return [
                 'completed' => true,
                 'url' => null,
                 'shop_id' => $shop->getId(),
+                'theme_support_level' => $themeSupportLevel,
             ];
         } catch (Exception $e) {
             // Just return the default setting
@@ -99,6 +115,7 @@ class InstallShop
                 'completed' => false,
                 'url' => null,
                 'shop_id' => null,
+                'theme_support_level' => null,
             ];
         }
     }

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -49,7 +49,7 @@ class InstallShop
     public function __construct(
         IShopQuery $shopQuery,
         IShopCommand $shopCommand,
-        VerifyThemeSupport $verifyThemeSupport,
+        VerifyThemeSupport $verifyThemeSupport
     ) {
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -2,10 +2,10 @@
 
 namespace Osiset\ShopifyApp\Actions;
 
-use Osiset\ShopifyApp\Services\ThemeHelper;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Services\ThemeHelper;
 
 /**
  * Activates a plan for a shop.
@@ -31,6 +31,7 @@ class VerifyThemeSupport
      *
      * @param IShopQuery     $shopQuery               The querier for shops.
      * @param ThemeHelper    $themeHelper             Theme helper.
+     *
      * @return void
      */
     public function __construct(

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -51,18 +51,16 @@ class VerifyThemeSupport
      */
     public function __invoke(ShopId $shopId): int
     {
-        $shop = $this->shopQuery->getById($shopId);
-        $this->themeHelper->extractStoreMainTheme($shop);
+        $this->themeHelper->extractStoreMainTheme($shopId);
 
         if ($this->themeHelper->themeIsReady()) {
             $templateJSONFiles = $this->themeHelper->templateJSONFiles();
-            $templateMainSections = $this->themeHelper->mainSections($shop, $templateJSONFiles);
-            $sectionsWithAppBlock = $this->themeHelper->sectionsWithAppBlock($shop, $templateMainSections);
+            $templateMainSections = $this->themeHelper->mainSections($templateJSONFiles);
+            $sectionsWithAppBlock = $this->themeHelper->sectionsWithAppBlock($templateMainSections);
 
             $hasTemplates = count($templateJSONFiles) > 0;
             $allTemplatesHasRightType = count($templateJSONFiles) === count($sectionsWithAppBlock);
             $templatesСountWithRightType = count($sectionsWithAppBlock);
-
 
             switch (true) {
                 case $hasTemplates && $allTemplatesHasRightType:

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -78,14 +78,4 @@ class VerifyThemeSupport
 
         return ThemeSupportLevel::UNSUPPORTED;
     }
-
-    /**
-     * Get theme helper.
-     *
-     * @return  ThemeHelper
-     */
-    public function getThemeHelper()
-    {
-        return $this->themeHelper;
-    }
 }

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -29,8 +29,8 @@ class VerifyThemeSupport
     /**
      * Setup.
      *
-     * @param IShopQuery     $shopQuery               The querier for shops.
-     * @param ThemeHelper    $themeHelper             Theme helper.
+     * @param IShopQuery  $shopQuery   The querier for shops.
+     * @param ThemeHelper $themeHelper Theme helper.
      *
      * @return void
      */

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -2,62 +2,16 @@
 
 namespace Osiset\ShopifyApp\Actions;
 
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Str;
-use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
-use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
-use Osiset\ShopifyApp\Contracts\ShopModel;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
-use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Services\ThemeHelper;
 use Osiset\ShopifyApp\Objects\Values\ShopId;
-use Osiset\ShopifyApp\Util;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 
 /**
  * Activates a plan for a shop.
  */
 class VerifyThemeSupport
 {
-    /**
-     * Main theme role
-     */
-    public const MAIN_ROLE = 'main';
-
-    /**
-     * Theme field
-     */
-    public const THEME_FIELD = 'role';
-
-    /**
-     * Asset field
-     */
-    public const ASSET_FIELD = 'key';
-
-    /**
-     * Interval for caching the request: minutes, seconds, hours, days, etc.
-     *
-     * @var string
-     */
-    protected $cacheInterval;
-
-    /**
-     * Cache duration
-     *
-     * @var int
-     */
-    protected $cacheDuration;
-
-    /**
-     * Shop main theme
-     *
-     * @var MainTheme
-     */
-    protected $mainTheme;
-
-    /**
-     * Theme assets
-     */
-    protected $assets;
-
     /**
      * Querier for shops.
      *
@@ -66,33 +20,25 @@ class VerifyThemeSupport
     protected $shopQuery;
 
     /**
-     * Command for shops.
+     * Theme helper.
      *
-     * @var IShopCommand
+     * @var ThemeHelper
      */
-    protected $shopCommand;
+    protected $themeHelper;
 
     /**
      * Setup.
      *
      * @param IShopQuery     $shopQuery               The querier for shops.
-     * @param IShopCommand   $shopCommand             The commands for shops.
-     *
+     * @param ThemeHelper    $themeHelper             Theme helper.
      * @return void
      */
     public function __construct(
         IShopQuery $shopQuery,
-        IShopCommand $shopCommand
+        ThemeHelper $themeHelper
     ) {
         $this->shopQuery = $shopQuery;
-        $this->shopCommand = $shopCommand;
-
-        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
-            ->plural()
-            ->ucfirst()
-            ->start('add')
-            ->__toString();
-        $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
+        $this->themeHelper = $themeHelper;
     }
 
     /**
@@ -105,19 +51,17 @@ class VerifyThemeSupport
     public function __invoke(ShopId $shopId): int
     {
         $shop = $this->shopQuery->getById($shopId);
+        $this->themeHelper->extractStoreMainTheme($shop);
 
-        $this->mainTheme = $this->extractStoreMainTheme($shop);
-
-        if ($this->mainTheme->getId()->toNative()) {
-            $this->assets = $this->extractThemeAssets($shop);
-
-            $templateJSONFiles = $this->templateJSONFiles();
-            $templateMainSections = $this->mainSections($shop, $templateJSONFiles);
-            $sectionsWithAppBlock = $this->sectionsWithAppBlock($shop, $templateMainSections);
+        if ($this->themeHelper->themeIsReady()) {
+            $templateJSONFiles = $this->themeHelper->templateJSONFiles();
+            $templateMainSections = $this->themeHelper->mainSections($shop, $templateJSONFiles);
+            $sectionsWithAppBlock = $this->themeHelper->sectionsWithAppBlock($shop, $templateMainSections);
 
             $hasTemplates = count($templateJSONFiles) > 0;
             $allTemplatesHasRightType = count($templateJSONFiles) === count($sectionsWithAppBlock);
             $templatesСountWithRightType = count($sectionsWithAppBlock);
+
 
             switch (true) {
                 case $hasTemplates && $allTemplatesHasRightType:
@@ -135,146 +79,12 @@ class VerifyThemeSupport
     }
 
     /**
-     * Extract store main theme
+     * Get theme helper.
      *
-     * @param ShopModel $shop
-     *
-     * @return MainTheme
+     * @return  ThemeHelper
      */
-    private function extractStoreMainTheme(ShopModel $shop): MainTheme
+    public function getThemeHelper()
     {
-        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
-
-        if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
-            $themes = $themesResponse['body']['themes']->toArray();
-            $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
-
-            return MainTheme::fromNative($themes[$key]);
-        }
-
-        return MainTheme::fromNative([]);
-    }
-
-    /**
-     * Extract main theme assets
-     *
-     * @param ShopModel $shop
-     *
-     * @return array
-     */
-    private function extractThemeAssets(ShopModel $shop): array
-    {
-        return Cache::remember(
-            "assets_{$this->mainTheme->getId()->toNative()}",
-            now()->{$this->cacheInterval}($this->cacheDuration),
-            function () use ($shop) {
-                return $shop->api()->rest(
-                    'GET',
-                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
-                )['body']['assets']->toArray();
-            }
-        );
-    }
-
-    /**
-     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
-     *
-     * @return array
-     */
-    private function templateJSONFiles(): array
-    {
-        return array_filter($this->assets, function ($asset) {
-            $match = false;
-            $blockTemplates = Util::getShopifyConfig('theme_support.templates');
-
-            foreach ($blockTemplates as $template) {
-                if ($asset['key'] == "templates/$template.json") {
-                    $match = true;
-
-                    break;
-                }
-            }
-
-            return $match;
-        });
-    }
-
-    /**
-     * Retrieve the body of JSON templates and find what section is set as `main`
-     *
-     * @param ShopModel $shop
-     * @param array $templateJSONFiles
-     *
-     * @return array
-     */
-    private function mainSections(ShopModel $shop, array $templateJSONFiles): array
-    {
-        return array_filter(array_map(function ($file) use ($shop) {
-            $assetResponse = $this->fetchAsset($shop, $file);
-            $asset = $assetResponse['body']['asset']->toArray();
-            $assetValue = json_decode($asset['value'], true);
-
-            $mainAsset = array_filter($assetValue['sections'], function ($value, $key) {
-                return $key == self::MAIN_ROLE || str_starts_with($value['type'], self::MAIN_ROLE);
-            }, ARRAY_FILTER_USE_BOTH);
-
-            if ($mainAsset) {
-                return array_merge(...array_filter($this->assets, function ($asset) use ($mainAsset) {
-                    return $asset['key'] === 'sections/'.end($mainAsset)['type'].'.liquid';
-                }));
-            }
-        }, $templateJSONFiles));
-    }
-
-    /**
-     * Request the content of each section and check if it has a schema that contains a block of type '@app'
-     *
-     * @param ShopModel $shop
-     * @param array $templateMainSections
-     *
-     * @return array
-     */
-    private function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
-    {
-        return array_filter(array_map(function ($file) use ($shop) {
-            $acceptsAppBlock = false;
-
-            $assetResponse = $this->fetchAsset($shop, $file);
-            $asset = $assetResponse['body']['asset']->toArray();
-
-            preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
-            $schema = json_decode($matches[1], true);
-
-            if ($schema && isset($schema['blocks'])) {
-                $acceptsAppBlock = in_array('@app', array_column($schema['blocks'], 'type'));
-            }
-
-            return $acceptsAppBlock ? $file : null;
-        }, $templateMainSections));
-    }
-
-    /**
-     * Fetch asset
-     *
-     * @param ShopModel $shop
-     * @param array $file
-     *
-     * @return array
-     */
-    private function fetchAsset(ShopModel $shop, array $file): array
-    {
-        return Cache::remember(
-            "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
-            now()->{$this->cacheInterval}($this->cacheDuration),
-            function () use ($shop, $file) {
-                return $shop->api()->rest(
-                    'GET',
-                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
-                    [
-                        'asset' => ['key' => $file['key']],
-                    ]
-                );
-            }
-        );
+        return $this->themeHelper;
     }
 }

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Osiset\ShopifyApp\Actions;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Contracts\ShopModel;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Util;
+
+/**
+ * Activates a plan for a shop.
+ */
+class VerifyThemeSupport
+{
+    /**
+     * Main theme role
+     */
+    public const MAIN_ROLE = 'main';
+
+    /**
+     * Theme field
+     */
+    public const THEME_FIELD = 'role';
+
+    /**
+     * Asset field
+     */
+    public const ASSET_FIELD = 'key';
+
+    /**
+     * Interval for caching the request: minutes, seconds, hours, days, etc.
+     *
+     * @var string
+     */
+    protected $cacheInterval;
+
+    /**
+     * Cache duration
+     *
+     * @var int
+     */
+    protected $cacheDuration;
+
+    /**
+     * Shop main theme
+     *
+     * @var MainTheme
+     */
+    protected $mainTheme;
+
+    /**
+     * Theme assets
+     */
+    protected $assets;
+
+    /**
+     * Querier for shops.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
+
+    /**
+     * Command for shops.
+     *
+     * @var IShopCommand
+     */
+    protected $shopCommand;
+
+    /**
+     * Setup.
+     *
+     * @param IShopQuery     $shopQuery               The querier for shops.
+     * @param IShopCommand   $shopCommand             The commands for shops.
+     *
+     * @return void
+     */
+    public function __construct(
+        IShopQuery $shopQuery,
+        IShopCommand $shopCommand
+    ) {
+        $this->shopQuery = $shopQuery;
+        $this->shopCommand = $shopCommand;
+
+        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
+            ->plural()
+            ->ucfirst()
+            ->start('add')
+            ->__toString();
+        $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
+    }
+
+    /**
+     * Execution.
+     *
+     * @param ShopId $shopId The shop ID.
+     *
+     * @return int
+     */
+    public function __invoke(ShopId $shopId): int
+    {
+        $shop = $this->shopQuery->getById($shopId);
+
+        $this->mainTheme = $this->extractStoreMainTheme($shop);
+
+        if ($this->mainTheme->getId()->toNative()) {
+            $this->assets = $this->extractThemeAssets($shop);
+
+            $templateJSONFiles = $this->templateJSONFiles();
+            $templateMainSections = $this->mainSections($shop, $templateJSONFiles);
+            $sectionsWithAppBlock = $this->sectionsWithAppBlock($shop, $templateMainSections);
+
+            $hasTemplates = count($templateJSONFiles) > 0;
+            $allTemplatesHasRightType = count($templateJSONFiles) === count($sectionsWithAppBlock);
+            $templatesСountWithRightType = count($sectionsWithAppBlock);
+
+            switch (true) {
+                case $hasTemplates && $allTemplatesHasRightType:
+                    return ThemeSupportLevel::FULL;
+
+                case $templatesСountWithRightType:
+                    return ThemeSupportLevel::PARTIAL;
+
+                default:
+                    return ThemeSupportLevel::UNSUPPORTED;
+            }
+        }
+
+        return ThemeSupportLevel::UNSUPPORTED;
+    }
+
+    /**
+     * Extract store main theme
+     *
+     * @param ShopModel $shop
+     *
+     * @return MainTheme
+     */
+    private function extractStoreMainTheme(ShopModel $shop): MainTheme
+    {
+        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
+
+        if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
+            $themes = $themesResponse['body']['themes']->toArray();
+            $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
+
+            return MainTheme::fromNative($themes[$key]);
+        }
+
+        return MainTheme::fromNative([]);
+    }
+
+    /**
+     * Extract main theme assets
+     *
+     * @param ShopModel $shop
+     *
+     * @return array
+     */
+    private function extractThemeAssets(ShopModel $shop): array
+    {
+        return Cache::remember(
+            "assets_{$this->mainTheme->getId()->toNative()}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
+                )['body']['assets']->toArray();
+            }
+        );
+    }
+
+    /**
+     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
+     *
+     * @return array
+     */
+    private function templateJSONFiles(): array
+    {
+        return array_filter($this->assets, function ($asset) {
+            $match = false;
+            $blockTemplates = Util::getShopifyConfig('theme_support.templates');
+
+            foreach ($blockTemplates as $template) {
+                if ($asset['key'] == "templates/$template.json") {
+                    $match = true;
+
+                    break;
+                }
+            }
+
+            return $match;
+        });
+    }
+
+    /**
+     * Retrieve the body of JSON templates and find what section is set as `main`
+     *
+     * @param ShopModel $shop
+     * @param array $templateJSONFiles
+     *
+     * @return array
+     */
+    private function mainSections(ShopModel $shop, array $templateJSONFiles): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+            $assetValue = json_decode($asset['value'], true);
+
+            $mainAsset = array_filter($assetValue['sections'], function ($value, $key) {
+                return $key == self::MAIN_ROLE || str_starts_with($value['type'], self::MAIN_ROLE);
+            }, ARRAY_FILTER_USE_BOTH);
+
+            if ($mainAsset) {
+                return array_merge(...array_filter($this->assets, function ($asset) use ($mainAsset) {
+                    return $asset['key'] === 'sections/'.end($mainAsset)['type'].'.liquid';
+                }));
+            }
+        }, $templateJSONFiles));
+    }
+
+    /**
+     * Request the content of each section and check if it has a schema that contains a block of type '@app'
+     *
+     * @param ShopModel $shop
+     * @param array $templateMainSections
+     *
+     * @return array
+     */
+    private function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $acceptsAppBlock = false;
+
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+
+            preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
+            $schema = json_decode($matches[1], true);
+
+            if ($schema && isset($schema['blocks'])) {
+                $acceptsAppBlock = in_array('@app', array_column($schema['blocks'], 'type'));
+            }
+
+            return $acceptsAppBlock ? $file : null;
+        }, $templateMainSections));
+    }
+
+    /**
+     * Fetch asset
+     *
+     * @param ShopModel $shop
+     * @param array $file
+     *
+     * @return array
+     */
+    private function fetchAsset(ShopModel $shop, array $file): array
+    {
+        return Cache::remember(
+            "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop, $file) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
+                    [
+                        'asset' => ['key' => $file['key']],
+                    ]
+                );
+            }
+        );
+    }
+}

--- a/src/Contracts/Commands/Shop.php
+++ b/src/Contracts/Commands/Shop.php
@@ -6,6 +6,7 @@ use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken as AccessTokenValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\PlanId as PlanIdValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopId as ShopIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
 
 /**
  * Represents commands for shops.
@@ -41,6 +42,16 @@ interface Shop
      * @return bool
      */
     public function setAccessToken(ShopIdValue $shopId, AccessTokenValue $token): bool;
+
+    /**
+     * Sets the Online Store 2.0 support level
+     *
+     * @param ShopIdValue       $shopId The shop's ID.
+     * @param ThemeSupportLevel $themeSupportLevel  Support level
+     *
+     * @return bool
+     */
+    public function setThemeSupportLevel(ShopIdValue $shopId, ThemeSupportLevelValue $themeSupportLevel): bool;
 
     /**
      * Cleans the shop's properties (token, plan).

--- a/src/Contracts/Objects/Values/ThemeId.php
+++ b/src/Contracts/Objects/Values/ThemeId.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's ID value object.
+ */
+interface ThemeId extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeName.php
+++ b/src/Contracts/Objects/Values/ThemeName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's name value object.
+ */
+interface ThemeName extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeRole.php
+++ b/src/Contracts/Objects/Values/ThemeRole.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Theme's role value object.
+ */
+interface ThemeRole extends ValueObject
+{
+}

--- a/src/Contracts/Objects/Values/ThemeSupportLevel.php
+++ b/src/Contracts/Objects/Values/ThemeSupportLevel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts\Objects\Values;
+
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Access token value object.
+ */
+interface ThemeSupportLevel extends ValueObject
+{
+}

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Enums;
+
+use Funeralzone\ValueObjects\Enums\EnumTrait;
+use Funeralzone\ValueObjects\ValueObject;
+
+/**
+ * Online Store 2.0 theme support
+ */
+class ThemeSupportLevel implements ValueObject
+{
+    use EnumTrait;
+
+    /**
+     * Support level: fully.
+     *
+     * @var int
+     */
+    public const FULL = 0;
+
+    /**
+     * Support level: partial.
+     *
+     * @var int
+     */
+    public const PARTIAL = 1;
+
+    /**
+     * Support level: unsupported.
+     *
+     * @var int
+     */
+    public const UNSUPPORTED = 2;
+}

--- a/src/Objects/Values/MainTheme.php
+++ b/src/Objects/Values/MainTheme.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\CompositeTrait;
+use Funeralzone\ValueObjects\ValueObject;
+use Illuminate\Support\Arr;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Used to inject current session data into the user's model.
+ * TODO: Possibly move this to a composite VO?
+ */
+final class MainTheme implements ValueObject
+{
+    use CompositeTrait;
+
+    /**
+     * Theme id
+     *
+     * @var ThemeId
+     */
+    protected $id;
+
+    /**
+     * Theme name
+     *
+     * @var ThemeName
+     */
+    protected $name;
+
+    /**
+     * Theme role
+     *
+     * @var ThemeRole
+     */
+    protected $role;
+
+    /**
+     * __construct
+     *
+     * @param ThemeIdValue $id
+     * @param ThemeNameValue $name
+     * @param ThemeRoleValue $role
+     */
+    public function __construct(ThemeIdValue $id, ThemeNameValue $name, ThemeRoleValue $role)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->role = $role;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromNative($native)
+    {
+        return new static(
+            NullableThemeId::fromNative(Arr::get($native, 'id')),
+            NullableThemeName::fromNative(Arr::get($native, 'name')),
+            NullableThemeRole::fromNative(Arr::get($native, 'role'))
+        );
+    }
+
+    /**
+     * Get theme id
+     *
+     * @return  ThemeId
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get theme name
+     *
+     * @return  ThemeName
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get theme role
+     *
+     * @return  ThemeRole
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+}

--- a/src/Objects/Values/NullThemeId.php
+++ b/src/Objects/Values/NullThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (null).
+ */
+final class NullThemeId implements ThemeIdValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeName.php
+++ b/src/Objects/Values/NullThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (null).
+ */
+final class NullThemeName implements ThemeNameValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullThemeRole.php
+++ b/src/Objects/Values/NullThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\NullTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (null).
+ */
+final class NullThemeRole implements ThemeRoleValue
+{
+    use NullTrait;
+}

--- a/src/Objects/Values/NullableThemeId.php
+++ b/src/Objects/Values/NullableThemeId.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID (nullable).
+ */
+final class NullableThemeId extends Nullable implements ThemeIdValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeId::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeId::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeName.php
+++ b/src/Objects/Values/NullableThemeName.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name (nullable).
+ */
+final class NullableThemeName extends Nullable implements ThemeNameValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeName::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeName::class;
+    }
+}

--- a/src/Objects/Values/NullableThemeRole.php
+++ b/src/Objects/Values/NullableThemeRole.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Nullable;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role (nullable).
+ */
+final class NullableThemeRole extends Nullable implements ThemeRoleValue
+{
+    /**
+     * @return string
+     */
+    protected static function nonNullImplementation(): string
+    {
+        return ThemeRole::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected static function nullImplementation(): string
+    {
+        return NullThemeRole::class;
+    }
+}

--- a/src/Objects/Values/ThemeId.php
+++ b/src/Objects/Values/ThemeId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\IntegerTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeId as ThemeIdValue;
+
+/**
+ * Value object for theme's ID.
+ */
+final class ThemeId implements ThemeIdValue
+{
+    use IntegerTrait;
+}

--- a/src/Objects/Values/ThemeName.php
+++ b/src/Objects/Values/ThemeName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeName as ThemeNameValue;
+
+/**
+ * Value object for theme's name.
+ */
+final class ThemeName implements ThemeNameValue
+{
+    use StringTrait;
+}

--- a/src/Objects/Values/ThemeRole.php
+++ b/src/Objects/Values/ThemeRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeRole as ThemeRoleValue;
+
+/**
+ * Value object for theme's role.
+ */
+final class ThemeRole implements ThemeRoleValue
+{
+    use StringTrait;
+}

--- a/src/Objects/Values/ThemeSupportLevel.php
+++ b/src/Objects/Values/ThemeSupportLevel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Osiset\ShopifyApp\Objects\Values;
+
+use Funeralzone\ValueObjects\Scalars\IntegerTrait;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
+
+/**
+ * Value object for shop's ID.
+ */
+final class ThemeSupportLevel implements ThemeSupportLevelValue
+{
+    use IntegerTrait;
+}

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -5,7 +5,7 @@ namespace Osiset\ShopifyApp\Services;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
-use Osiset\ShopifyApp\Contracts\ShopModel;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
 use Osiset\ShopifyApp\Objects\Values\MainTheme;
 use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Util;
@@ -33,9 +33,9 @@ class ThemeHelper
     /**
      * Current shop instance
      *
-     * @var ShopModel
+     * @var IShopModel
      */
-    protected ShopModel $shop;
+    protected IShopModel $shop;
 
     /**
      * Querier for shops.
@@ -73,7 +73,7 @@ class ThemeHelper
     /**
      * Setup.
      *
-     * @param IShopQuery     $shopQuery               The querier for shops.
+     * @param IShopQuery     $shopQuery The querier for shops.
      *
      * @return void
      */
@@ -125,8 +125,6 @@ class ThemeHelper
 
     /**
      * Extract main theme assets
-     *
-     * @param ShopModel $shop
      *
      * @return void
      */

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -35,7 +35,7 @@ class ThemeHelper
      *
      * @var IShopModel
      */
-    protected IShopModel $shop;
+    protected $shop;
 
     /**
      * Querier for shops.

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -156,6 +156,7 @@ class ThemeHelper
             foreach ($blockTemplates as $template) {
                 if ($asset['key'] == "templates/$template.json") {
                     $match = true;
+
                     break;
                 }
             }

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -4,8 +4,10 @@ namespace Osiset\ShopifyApp\Services;
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 use Osiset\ShopifyApp\Contracts\ShopModel;
 use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Util;
 
 /**
@@ -27,6 +29,20 @@ class ThemeHelper
      * Asset field
      */
     public const ASSET_FIELD = 'key';
+
+    /**
+     * Current shop instance
+     *
+     * @var ShopModel
+     */
+    protected ShopModel $shop;
+
+    /**
+     * Querier for shops.
+     *
+     * @var IShopQuery
+     */
+    protected $shopQuery;
 
     /**
      * Interval for caching the request: minutes, seconds, hours, days, etc.
@@ -55,17 +71,21 @@ class ThemeHelper
     protected $assets;
 
     /**
-     * Constructor.
+     * Setup.
+     *
+     * @param IShopQuery     $shopQuery               The querier for shops.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(IShopQuery $shopQuery)
     {
-        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
+        $this->shopQuery = $shopQuery;
+
+        $this->cacheInterval = (string) Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
             ->plural()
             ->ucfirst()
-            ->start('add')
-            ->__toString();
+            ->start('add');
+
         $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
     }
 
@@ -82,20 +102,22 @@ class ThemeHelper
     /**
      * Extract store main theme
      *
-     * @param ShopModel $shop
+     * @param ShopId $shopId The shop ID.
      *
      * @return void
      */
-    public function extractStoreMainTheme(ShopModel $shop): void
+    public function extractStoreMainTheme(ShopId $shopId): void
     {
-        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
+        $this->shop = $this->shopQuery->getById($shopId);
+
+        $themesResponse = $this->shop->api()->rest('GET', '/admin/themes.json');
 
         if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
             $themes = $themesResponse['body']['themes']->toArray();
-            $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
+            $key = array_search(self::MAIN_ROLE, array_column($themes, self::THEME_FIELD));
 
             $this->mainTheme = MainTheme::fromNative($themes[$key]);
-            $this->extractThemeAssets($shop);
+            $this->extractThemeAssets();
         } else {
             $this->mainTheme = MainTheme::fromNative([]);
         }
@@ -108,13 +130,13 @@ class ThemeHelper
      *
      * @return void
      */
-    private function extractThemeAssets(ShopModel $shop): void
+    private function extractThemeAssets(): void
     {
         $this->assets = Cache::remember(
             "assets_{$this->mainTheme->getId()->toNative()}",
             now()->{$this->cacheInterval}($this->cacheDuration),
-            function () use ($shop) {
-                return $shop->api()->rest(
+            function () {
+                return $this->shop->api()->rest(
                     'GET',
                     "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
                 )['body']['assets']->toArray();
@@ -148,15 +170,14 @@ class ThemeHelper
     /**
      * Retrieve the body of JSON templates and find what section is set as `main`
      *
-     * @param ShopModel $shop
      * @param array $templateJSONFiles
      *
      * @return array
      */
-    public function mainSections(ShopModel $shop, array $templateJSONFiles): array
+    public function mainSections(array $templateJSONFiles): array
     {
-        return array_filter(array_map(function ($file) use ($shop) {
-            $assetResponse = $this->fetchAsset($shop, $file);
+        return array_filter(array_map(function ($file) {
+            $assetResponse = $this->fetchAsset($file);
             $asset = $assetResponse['body']['asset']->toArray();
             $assetValue = json_decode($asset['value'], true);
 
@@ -175,17 +196,16 @@ class ThemeHelper
     /**
      * Request the content of each section and check if it has a schema that contains a block of type '@app'
      *
-     * @param ShopModel $shop
      * @param array $templateMainSections
      *
      * @return array
      */
-    public function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
+    public function sectionsWithAppBlock(array $templateMainSections): array
     {
-        return array_filter(array_map(function ($file) use ($shop) {
+        return array_filter(array_map(function ($file) {
             $acceptsAppBlock = false;
 
-            $assetResponse = $this->fetchAsset($shop, $file);
+            $assetResponse = $this->fetchAsset($file);
             $asset = $assetResponse['body']['asset']->toArray();
 
             preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
@@ -202,18 +222,17 @@ class ThemeHelper
     /**
      * Fetch asset
      *
-     * @param ShopModel $shop
      * @param array $file
      *
      * @return array
      */
-    private function fetchAsset(ShopModel $shop, array $file): array
+    private function fetchAsset(array $file): array
     {
         return Cache::remember(
             "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
             now()->{$this->cacheInterval}($this->cacheDuration),
-            function () use ($shop, $file) {
-                return $shop->api()->rest(
+            function () use ($file) {
+                return $this->shop->api()->rest(
                     'GET',
                     "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
                     [

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -11,27 +11,27 @@ use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Util;
 
 /**
- * Helper for dealing with cookie and cookie issues.
+ * Helper for dealing with theme and theme assets.
  */
 class ThemeHelper
 {
     /**
-     * Main theme role
+     * Main theme role.
      */
     public const MAIN_ROLE = 'main';
 
     /**
-     * Theme field
+     * Theme field.
      */
     public const THEME_FIELD = 'role';
 
     /**
-     * Asset field
+     * Asset field.
      */
     public const ASSET_FIELD = 'key';
 
     /**
-     * Current shop instance
+     * Current shop instance.
      *
      * @var IShopModel
      */
@@ -52,28 +52,28 @@ class ThemeHelper
     protected $cacheInterval;
 
     /**
-     * Cache duration
+     * Cache duration.
      *
      * @var int
      */
     protected $cacheDuration;
 
     /**
-     * Shop main theme
+     * Shop main theme.
      *
      * @var MainTheme
      */
     protected $mainTheme;
 
     /**
-     * Theme assets
+     * Theme assets.
      */
     protected $assets;
 
     /**
      * Setup.
      *
-     * @param IShopQuery     $shopQuery The querier for shops.
+     * @param IShopQuery $shopQuery The querier for shops.
      *
      * @return void
      */
@@ -90,7 +90,7 @@ class ThemeHelper
     }
 
     /**
-     * Theme is set and ready for testing
+     * Determine if theme is set and ready for testing.
      *
      * @return bool
      */
@@ -100,7 +100,7 @@ class ThemeHelper
     }
 
     /**
-     * Extract store main theme
+     * Extract store's main theme.
      *
      * @param ShopId $shopId The shop ID.
      *
@@ -111,7 +111,6 @@ class ThemeHelper
         $this->shop = $this->shopQuery->getById($shopId);
 
         $themesResponse = $this->shop->api()->rest('GET', '/admin/themes.json');
-
         if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
             $themes = $themesResponse['body']['themes']->toArray();
             $key = array_search(self::MAIN_ROLE, array_column($themes, self::THEME_FIELD));
@@ -124,7 +123,7 @@ class ThemeHelper
     }
 
     /**
-     * Extract main theme assets
+     * Extract main theme's assets.
      *
      * @return void
      */
@@ -143,7 +142,8 @@ class ThemeHelper
     }
 
     /**
-     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
+     * Check if JSON template files exist for
+     * the template specified in `APP_BLOCK_TEMPLATES`.
      *
      * @return array
      */
@@ -156,7 +156,6 @@ class ThemeHelper
             foreach ($blockTemplates as $template) {
                 if ($asset['key'] == "templates/$template.json") {
                     $match = true;
-
                     break;
                 }
             }
@@ -166,9 +165,9 @@ class ThemeHelper
     }
 
     /**
-     * Retrieve the body of JSON templates and find what section is set as `main`
+     * Retrieve the body of JSON templates and find what section is set as `main`.
      *
-     * @param array $templateJSONFiles
+     * @param array $templateJSONFiles The template files to filter through.
      *
      * @return array
      */
@@ -192,9 +191,10 @@ class ThemeHelper
     }
 
     /**
-     * Request the content of each section and check if it has a schema that contains a block of type '@app'
+     * Request the contents of each section then check
+     * if it has a schema that contains a block of type '@app'.
      *
-     * @param array $templateMainSections
+     * @param array $templateMainSections The template's main sections to filter through.
      *
      * @return array
      */
@@ -218,9 +218,9 @@ class ThemeHelper
     }
 
     /**
-     * Fetch asset
+     * Fetch a theme's asset.
      *
-     * @param array $file
+     * @param array $file The theme file information to fetch or retrieve from cache.
      *
      * @return array
      */

--- a/src/Services/ThemeHelper.php
+++ b/src/Services/ThemeHelper.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Osiset\ShopifyApp\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Osiset\ShopifyApp\Contracts\ShopModel;
+use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Util;
+
+/**
+ * Helper for dealing with cookie and cookie issues.
+ */
+class ThemeHelper
+{
+    /**
+     * Main theme role
+     */
+    public const MAIN_ROLE = 'main';
+
+    /**
+     * Theme field
+     */
+    public const THEME_FIELD = 'role';
+
+    /**
+     * Asset field
+     */
+    public const ASSET_FIELD = 'key';
+
+    /**
+     * Interval for caching the request: minutes, seconds, hours, days, etc.
+     *
+     * @var string
+     */
+    protected $cacheInterval;
+
+    /**
+     * Cache duration
+     *
+     * @var int
+     */
+    protected $cacheDuration;
+
+    /**
+     * Shop main theme
+     *
+     * @var MainTheme
+     */
+    protected $mainTheme;
+
+    /**
+     * Theme assets
+     */
+    protected $assets;
+
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->cacheInterval = Str::of(Util::getShopifyConfig('theme_support.cache_interval'))
+            ->plural()
+            ->ucfirst()
+            ->start('add')
+            ->__toString();
+        $this->cacheDuration = Util::getShopifyConfig('theme_support.cache_duration');
+    }
+
+    /**
+     * Theme is set and ready for testing
+     *
+     * @return bool
+     */
+    public function themeIsReady(): bool
+    {
+        return (bool) $this->mainTheme->getId()->toNative();
+    }
+
+    /**
+     * Extract store main theme
+     *
+     * @param ShopModel $shop
+     *
+     * @return void
+     */
+    public function extractStoreMainTheme(ShopModel $shop): void
+    {
+        $themesResponse = $shop->api()->rest('GET', '/admin/themes.json');
+
+        if (!$themesResponse['errors'] && isset($themesResponse['body']['themes'])) {
+            $themes = $themesResponse['body']['themes']->toArray();
+            $key = array_search($this::MAIN_ROLE, array_column($themes, $this::THEME_FIELD));
+
+            $this->mainTheme = MainTheme::fromNative($themes[$key]);
+            $this->extractThemeAssets($shop);
+        } else {
+            $this->mainTheme = MainTheme::fromNative([]);
+        }
+    }
+
+    /**
+     * Extract main theme assets
+     *
+     * @param ShopModel $shop
+     *
+     * @return void
+     */
+    private function extractThemeAssets(ShopModel $shop): void
+    {
+        $this->assets = Cache::remember(
+            "assets_{$this->mainTheme->getId()->toNative()}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets.json"
+                )['body']['assets']->toArray();
+            }
+        );
+    }
+
+    /**
+     * Check if JSON template files exist for the template specified in APP_BLOCK_TEMPLATES
+     *
+     * @return array
+     */
+    public function templateJSONFiles(): array
+    {
+        return array_filter($this->assets, function ($asset) {
+            $match = false;
+            $blockTemplates = Util::getShopifyConfig('theme_support.templates');
+
+            foreach ($blockTemplates as $template) {
+                if ($asset['key'] == "templates/$template.json") {
+                    $match = true;
+
+                    break;
+                }
+            }
+
+            return $match;
+        });
+    }
+
+    /**
+     * Retrieve the body of JSON templates and find what section is set as `main`
+     *
+     * @param ShopModel $shop
+     * @param array $templateJSONFiles
+     *
+     * @return array
+     */
+    public function mainSections(ShopModel $shop, array $templateJSONFiles): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+            $assetValue = json_decode($asset['value'], true);
+
+            $mainAsset = array_filter($assetValue['sections'], function ($value, $key) {
+                return $key == self::MAIN_ROLE || str_starts_with($value['type'], self::MAIN_ROLE);
+            }, ARRAY_FILTER_USE_BOTH);
+
+            if ($mainAsset) {
+                return array_merge(...array_filter($this->assets, function ($asset) use ($mainAsset) {
+                    return $asset['key'] === 'sections/'.end($mainAsset)['type'].'.liquid';
+                }));
+            }
+        }, $templateJSONFiles));
+    }
+
+    /**
+     * Request the content of each section and check if it has a schema that contains a block of type '@app'
+     *
+     * @param ShopModel $shop
+     * @param array $templateMainSections
+     *
+     * @return array
+     */
+    public function sectionsWithAppBlock(ShopModel $shop, array $templateMainSections): array
+    {
+        return array_filter(array_map(function ($file) use ($shop) {
+            $acceptsAppBlock = false;
+
+            $assetResponse = $this->fetchAsset($shop, $file);
+            $asset = $assetResponse['body']['asset']->toArray();
+
+            preg_match('/\{\%\s+schema\s+\%\}([\s\S]*?)\{\%\s+endschema\s+\%\}/m', $asset['value'], $matches);
+            $schema = json_decode($matches[1], true);
+
+            if ($schema && isset($schema['blocks'])) {
+                $acceptsAppBlock = in_array('@app', array_column($schema['blocks'], 'type'));
+            }
+
+            return $acceptsAppBlock ? $file : null;
+        }, $templateMainSections));
+    }
+
+    /**
+     * Fetch asset
+     *
+     * @param ShopModel $shop
+     * @param array $file
+     *
+     * @return array
+     */
+    private function fetchAsset(ShopModel $shop, array $file): array
+    {
+        return Cache::remember(
+            "asset_{$this->mainTheme->getId()->toNative()}_{$file['key']}",
+            now()->{$this->cacheInterval}($this->cacheDuration),
+            function () use ($shop, $file) {
+                return $shop->api()->rest(
+                    'GET',
+                    "/admin/themes/{$this->mainTheme->getId()->toNative()}/assets",
+                    [
+                        'asset' => ['key' => $file['key']],
+                    ]
+                );
+            }
+        );
+    }
+}

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -39,6 +39,7 @@ use Osiset\ShopifyApp\Messaging\Jobs\ScripttagInstaller;
 use Osiset\ShopifyApp\Messaging\Jobs\WebhookInstaller;
 use Osiset\ShopifyApp\Services\ApiHelper;
 use Osiset\ShopifyApp\Services\ChargeHelper;
+use Osiset\ShopifyApp\Services\ThemeHelper;
 use Osiset\ShopifyApp\Storage\Commands\Charge as ChargeCommand;
 use Osiset\ShopifyApp\Storage\Commands\Shop as ShopCommand;
 use Osiset\ShopifyApp\Storage\Observers\Shop as ShopObserver;
@@ -177,7 +178,7 @@ class ShopifyAppProvider extends ServiceProvider
         $this->app->bind(VerifyThemeSupportAction::class, function ($app) {
             return new VerifyThemeSupportAction(
                 $app->make(IShopQuery::class),
-                $app->make(IShopCommand::class)
+                $app->make(ThemeHelper::class)
             );
         });
 

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -19,6 +19,7 @@ use Osiset\ShopifyApp\Actions\DispatchScripts as DispatchScriptsAction;
 use Osiset\ShopifyApp\Actions\DispatchWebhooks as DispatchWebhooksAction;
 use Osiset\ShopifyApp\Actions\GetPlanUrl as GetPlanUrlAction;
 use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
+use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;
@@ -120,6 +121,7 @@ class ShopifyAppProvider extends ServiceProvider
             return new AuthenticateShopAction(
                 $app->make(IApiHelper::class),
                 $app->make(InstallShopAction::class),
+                $app->make(VerifyThemeSupportAction::class),
                 $app->make(DispatchScriptsAction::class),
                 $app->make(DispatchWebhooksAction::class),
                 $app->make(AfterAuthorizeAction::class)
@@ -167,6 +169,13 @@ class ShopifyAppProvider extends ServiceProvider
                 $app->make(IShopQuery::class),
                 $app->make(IPlanQuery::class),
                 $app->make(IChargeCommand::class),
+                $app->make(IShopCommand::class)
+            );
+        });
+
+        $this->app->bind(VerifyThemeSupportAction::class, function ($app) {
+            return new VerifyThemeSupportAction(
+                $app->make(IShopQuery::class),
                 $app->make(IShopCommand::class)
             );
         });

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -113,7 +113,8 @@ class ShopifyAppProvider extends ServiceProvider
         $this->app->bind(InstallShopAction::class, function ($app) {
             return new InstallShopAction(
                 $app->make(IShopQuery::class),
-                $app->make(IShopCommand::class)
+                $app->make(IShopCommand::class),
+                $app->make(VerifyThemeSupportAction::class),
             );
         });
 

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -123,7 +123,6 @@ class ShopifyAppProvider extends ServiceProvider
             return new AuthenticateShopAction(
                 $app->make(IApiHelper::class),
                 $app->make(InstallShopAction::class),
-                $app->make(VerifyThemeSupportAction::class),
                 $app->make(DispatchScriptsAction::class),
                 $app->make(DispatchWebhooksAction::class),
                 $app->make(AfterAuthorizeAction::class)

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -20,6 +20,7 @@ use Osiset\ShopifyApp\Actions\DispatchWebhooks as DispatchWebhooksAction;
 use Osiset\ShopifyApp\Actions\GetPlanUrl as GetPlanUrlAction;
 use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
 use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
+use Osiset\ShopifyApp\Console\AddVariablesCommand;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -115,7 +115,7 @@ class ShopifyAppProvider extends ServiceProvider
             return new InstallShopAction(
                 $app->make(IShopQuery::class),
                 $app->make(IShopCommand::class),
-                $app->make(VerifyThemeSupportAction::class),
+                $app->make(VerifyThemeSupportAction::class)
             );
         });
 

--- a/src/Storage/Commands/Shop.php
+++ b/src/Storage/Commands/Shop.php
@@ -8,6 +8,7 @@ use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken as AccessTokenValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\PlanId as PlanIdValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopId as ShopIdValue;
+use Osiset\ShopifyApp\Contracts\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as ShopQuery;
 use Osiset\ShopifyApp\Contracts\ShopModel;
 use Osiset\ShopifyApp\Util;
@@ -75,6 +76,17 @@ class Shop implements ShopCommand
         $shop = $this->getShop($shopId);
         $shop->password = $token->toNative();
         $shop->password_updated_at = Carbon::now();
+
+        return $shop->save();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setThemeSupportLevel(ShopIdValue $shopId, ThemeSupportLevelValue $themeSupportLevel): bool
+    {
+        $shop = $this->getShop($shopId);
+        $shop->theme_support_level = $themeSupportLevel->toNative();
 
         return $shop->save();
     }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -197,7 +197,7 @@ return [
     |
     */
 
-    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products'),
+    'api_scopes' => env('SHOPIFY_API_SCOPES', 'read_products,write_products,read_themes'),
 
     /*
     |--------------------------------------------------------------------------
@@ -470,5 +470,36 @@ return [
         * The table name for Plan model.
         */
         'plans' => 'plans',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Checking theme compatibility
+    |--------------------------------------------------------------------------
+    |
+    | It is necessary to check if your application is compatible with the theme app blocks.
+    |
+    */
+    'theme_support' => [
+        /**
+         * Specify the name of the template the app will integrate with
+         */
+        'templates' => ['product', 'collection', 'index'],
+        /**
+         * Interval for caching the request: minutes, seconds, hours, days, etc.
+         */
+        'cache_interval' => 'hours',
+        /**
+         * Cache duration
+         */
+        'cache_duration' => '12',
+         /**
+         * At which levels of theme support the use of "theme app extension" is not available
+         * and script tags will be installed.
+         * Available levels: FULL, PARTIAL, UNSUPPORTED.
+         */
+        'unacceptable_levels' => [
+            Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED
+        ]
     ]
 ];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -503,7 +503,7 @@ return [
         'unacceptable_levels' => [
             Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED
         ]
-    ]
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/resources/database/migrations/2022_06_09_104819_add_theme_support_level_to_users_table.php
+++ b/src/resources/database/migrations/2022_06_09_104819_add_theme_support_level_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddThemeSupportLevelToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('theme_support_level')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('theme_support_level');
+        });
+    }
+}

--- a/tests/Actions/InstallShopTest.php
+++ b/tests/Actions/InstallShopTest.php
@@ -31,7 +31,7 @@ class InstallShopTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
+            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
             $result['url']
         );
         $this->assertFalse($result['completed']);
@@ -50,7 +50,7 @@ class InstallShopTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
+            '/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate',
             $result['url']
         );
         $this->assertFalse($result['completed']);

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -2,12 +2,12 @@
 
 namespace Osiset\ShopifyApp\Test\Actions;
 
-use Osiset\ShopifyApp\Actions\VerifyThemeSupport;
-use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
-use Osiset\ShopifyApp\Services\ThemeHelper;
 use Osiset\ShopifyApp\Test\TestCase;
+use Osiset\ShopifyApp\Services\ThemeHelper;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Actions\VerifyThemeSupport;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 
 class VerifyThemeSupportTest extends TestCase
 {
@@ -38,14 +38,7 @@ class VerifyThemeSupportTest extends TestCase
     public function testStoreWithFullExtensionSupport(): void
     {
         $shop = factory($this->model)->create();
-        $defaultThemeResponse = [0, 1, 2, 3];
-
-        $themeHelperStub = $this->createStub(ThemeHelper::class);
-        $themeHelperStub->method('themeIsReady')->willReturn(true);
-        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('sectionsWithAppBlock')->willReturn($defaultThemeResponse);
-
+        $themeHelperStub = $this->createThemeHelperStub(ThemeSupportLevel::FULL);
         $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
 
         $result = call_user_func(
@@ -60,14 +53,7 @@ class VerifyThemeSupportTest extends TestCase
     public function testStoreWithPartialExtensionSupport(): void
     {
         $shop = factory($this->model)->create();
-        $defaultThemeResponse = [0, 1, 2, 3];
-
-        $themeHelperStub = $this->createStub(ThemeHelper::class);
-        $themeHelperStub->method('themeIsReady')->willReturn(true);
-        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('sectionsWithAppBlock')->willReturn([...$defaultThemeResponse, random_int(1, 99)]);
-
+        $themeHelperStub = $this->createThemeHelperStub(ThemeSupportLevel::PARTIAL);
         $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
 
         $result = call_user_func(
@@ -82,14 +68,7 @@ class VerifyThemeSupportTest extends TestCase
     public function testStoreWithoutExtensionSupport(): void
     {
         $shop = factory($this->model)->create();
-        $defaultThemeResponse = [];
-
-        $themeHelperStub = $this->createStub(ThemeHelper::class);
-        $themeHelperStub->method('themeIsReady')->willReturn(true);
-        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
-        $themeHelperStub->method('sectionsWithAppBlock')->willReturn($defaultThemeResponse);
-
+        $themeHelperStub = $this->createThemeHelperStub(ThemeSupportLevel::UNSUPPORTED);
         $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
 
         $result = call_user_func(
@@ -99,5 +78,33 @@ class VerifyThemeSupportTest extends TestCase
 
         $this->assertNotNull($result);
         $this->assertEquals(ThemeSupportLevel::UNSUPPORTED, $result);
+    }
+
+    /**
+     * Create ThemeHelper stub
+     *
+     * @param int $level
+     * @return ThemeHelper
+     */
+    protected function createThemeHelperStub(int $level): ThemeHelper
+    {
+        $themeHelperStub = $this->createStub(ThemeHelper::class);
+
+        $defaultThemeResponse = [];
+
+        if ($level === ThemeSupportLevel::FULL) {
+            $defaultThemeResponse = [0, 1, 2, 3];
+        }
+
+        $themeHelperStub->method('themeIsReady')->willReturn(true);
+        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('sectionsWithAppBlock')->willReturn(
+            $level === ThemeSupportLevel::PARTIAL
+            ? [...$defaultThemeResponse, random_int(1, 99)]
+            : $defaultThemeResponse
+        );
+
+        return $themeHelperStub;
     }
 }

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -2,12 +2,12 @@
 
 namespace Osiset\ShopifyApp\Test\Actions;
 
-use Osiset\ShopifyApp\Test\TestCase;
-use Osiset\ShopifyApp\Services\ThemeHelper;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Actions\VerifyThemeSupport;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Services\ThemeHelper;
+use Osiset\ShopifyApp\Test\TestCase;
 
 class VerifyThemeSupportTest extends TestCase
 {

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -102,7 +102,7 @@ class VerifyThemeSupportTest extends TestCase
         $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
         $themeHelperStub->method('sectionsWithAppBlock')->willReturn(
             $level === ThemeSupportLevel::PARTIAL
-            ? [...$defaultThemeResponse, random_int(1, 99)]
+            ? array_merge($defaultThemeResponse, [random_int(1, 99)])
             : $defaultThemeResponse
         );
 

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -2,12 +2,12 @@
 
 namespace Osiset\ShopifyApp\Test\Actions;
 
-use Osiset\ShopifyApp\Test\TestCase;
-use Osiset\ShopifyApp\Services\ThemeHelper;
-use Osiset\ShopifyApp\Objects\Values\ShopId;
 use Osiset\ShopifyApp\Actions\VerifyThemeSupport;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Services\ThemeHelper;
+use Osiset\ShopifyApp\Test\TestCase;
 
 class VerifyThemeSupportTest extends TestCase
 {
@@ -84,6 +84,7 @@ class VerifyThemeSupportTest extends TestCase
      * Create ThemeHelper stub
      *
      * @param int $level
+     *
      * @return ThemeHelper
      */
     protected function createThemeHelperStub(int $level): ThemeHelper

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -11,11 +11,6 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class VerifyThemeSupportTest extends TestCase
 {
-    /**
-     * @var \Osiset\ShopifyApp\Actions\InstallShop
-     */
-    protected $action;
-
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Actions;
+
+use Osiset\ShopifyApp\Test\TestCase;
+use Osiset\ShopifyApp\Services\ThemeHelper;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Actions\VerifyThemeSupport;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+
+class VerifyThemeSupportTest extends TestCase
+{
+    /**
+     * @var \Osiset\ShopifyApp\Actions\InstallShop
+     */
+    protected $action;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testStoreWithUndefinedMainTheme(): void
+    {
+        $shop = factory($this->model)->create();
+        $action = $this->app->make(VerifyThemeSupport::class);
+
+        $result = call_user_func(
+            $action,
+            ShopId::fromNative($shop->id)
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals(ThemeSupportLevel::UNSUPPORTED, $result);
+    }
+
+    public function testStoreWithFullExtensionSupport(): void
+    {
+        $shop = factory($this->model)->create();
+        $defaultThemeResponse = [0, 1, 2, 3];
+
+        $themeHelperStub = $this->createStub(ThemeHelper::class);
+        $themeHelperStub->method('themeIsReady')->willReturn(true);
+        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('sectionsWithAppBlock')->willReturn($defaultThemeResponse);
+
+        $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
+
+        $result = call_user_func(
+            $action,
+            ShopId::fromNative($shop->id)
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals(ThemeSupportLevel::FULL, $result);
+    }
+
+    public function testStoreWithPartialExtensionSupport(): void
+    {
+        $shop = factory($this->model)->create();
+        $defaultThemeResponse = [0, 1, 2, 3];
+
+        $themeHelperStub = $this->createStub(ThemeHelper::class);
+        $themeHelperStub->method('themeIsReady')->willReturn(true);
+        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('sectionsWithAppBlock')->willReturn([...$defaultThemeResponse, random_int(1, 99)]);
+
+        $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
+
+        $result = call_user_func(
+            $action,
+            ShopId::fromNative($shop->id)
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals(ThemeSupportLevel::PARTIAL, $result);
+    }
+
+    public function testStoreWithoutExtensionSupport(): void
+    {
+        $shop = factory($this->model)->create();
+        $defaultThemeResponse = [];
+
+        $themeHelperStub = $this->createStub(ThemeHelper::class);
+        $themeHelperStub->method('themeIsReady')->willReturn(true);
+        $themeHelperStub->method('templateJSONFiles')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('mainSections')->willReturn($defaultThemeResponse);
+        $themeHelperStub->method('sectionsWithAppBlock')->willReturn($defaultThemeResponse);
+
+        $action = new VerifyThemeSupport($this->app->make(IShopQuery::class), $themeHelperStub);
+
+        $result = call_user_func(
+            $action,
+            ShopId::fromNative($shop->id)
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals(ThemeSupportLevel::UNSUPPORTED, $result);
+    }
+}

--- a/tests/Objects/Values/MainThemeTest.php
+++ b/tests/Objects/Values/MainThemeTest.php
@@ -10,11 +10,11 @@ use Osiset\ShopifyApp\Test\TestCase;
 
 class MainThemeTest extends TestCase
 {
-    const THEME_ID = 1;
+    public const THEME_ID = 1;
 
-    const THEME_NAME = 'Dawn';
+    public const THEME_NAME = 'Dawn';
 
-    const THEME_ROLE = 'main';
+    public const THEME_ROLE = 'main';
 
     /**
      * @var MainTheme
@@ -28,7 +28,7 @@ class MainThemeTest extends TestCase
         $this->mainTheme = MainTheme::fromNative([
             'id' => self::THEME_ID,
             'name' => self::THEME_NAME,
-            'role' => self::THEME_ROLE
+            'role' => self::THEME_ROLE,
         ]);
     }
 

--- a/tests/Objects/Values/MainThemeTest.php
+++ b/tests/Objects/Values/MainThemeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Objects\Values;
+
+use Osiset\ShopifyApp\Objects\Values\MainTheme;
+use Osiset\ShopifyApp\Objects\Values\NullableThemeId;
+use Osiset\ShopifyApp\Objects\Values\NullableThemeName;
+use Osiset\ShopifyApp\Objects\Values\NullableThemeRole;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class MainThemeTest extends TestCase
+{
+    const THEME_ID = 1;
+
+    const THEME_NAME = 'Dawn';
+
+    const THEME_ROLE = 'main';
+
+    /**
+     * @var MainTheme
+     */
+    protected $mainTheme;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mainTheme = MainTheme::fromNative([
+            'id' => self::THEME_ID,
+            'name' => self::THEME_NAME,
+            'role' => self::THEME_ROLE
+        ]);
+    }
+
+    public function testGetMainThemeId()
+    {
+        $themeId = $this->mainTheme->getId();
+
+        $this->assertInstanceOf(NullableThemeId::class, $themeId);
+        $this->assertEquals($themeId->toNative(), self::THEME_ID);
+    }
+
+    public function testGetMainThemeName()
+    {
+        $themeName = $this->mainTheme->getName();
+
+        $this->assertInstanceOf(NullableThemeName::class, $themeName);
+        $this->assertEquals($themeName->toNative(), self::THEME_NAME);
+    }
+
+    public function testGetMainThemeRole()
+    {
+        $themeRole = $this->mainTheme->getRole();
+
+        $this->assertInstanceOf(NullableThemeRole::class, $themeRole);
+        $this->assertEquals($themeRole->toNative(), self::THEME_ROLE);
+    }
+}

--- a/tests/Services/ThemeHelperTest.php
+++ b/tests/Services/ThemeHelperTest.php
@@ -3,8 +3,8 @@
 namespace Osiset\ShopifyApp\Test\Services;
 
 use Osiset\ShopifyApp\Services\ThemeHelper;
-use Osiset\ShopifyApp\Test\TestCase;
 use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
 
 class ThemeHelperTest extends TestCase
 {

--- a/tests/Services/ThemeHelperTest.php
+++ b/tests/Services/ThemeHelperTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Services;
+
+use Osiset\ShopifyApp\Services\ThemeHelper;
+use Osiset\ShopifyApp\Test\TestCase;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+
+class ThemeHelperTest extends TestCase
+{
+    /**
+     * @var \Osiset\ShopifyApp\Services\ThemeHelper
+     */
+    protected $helper;
+
+    /**
+     * @var \Osiset\ShopifyApp\Contracts\ShopModel
+     */
+    protected $shop;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Init class and create a shop
+        $this->helper = $this->app->make(ThemeHelper::class);
+        $this->shop = factory($this->model)->create();
+    }
+
+    public function testThemeIsReady(): void
+    {
+        // Response stubbing
+        $this->setApiStub();
+        ApiStub::stubResponses(['get_themes', 'get_theme_assets']);
+
+        // Run extraction
+        $this->helper->extractStoreMainTheme($this->shop->getId());
+
+        $this->assertTrue($this->helper->themeIsReady());
+    }
+
+    public function testThemeIsReadyFailure(): void
+    {
+        // Response stubbing
+        $this->setApiStub();
+        ApiStub::stubResponses(['empty_with_error']);
+
+        // Run extraction
+        $this->helper->extractStoreMainTheme($this->shop->getId());
+
+        $this->assertFalse($this->helper->themeIsReady());
+    }
+
+    public function testTemplateJsonFiles(): void
+    {
+        // Response stubbing
+        $this->setApiStub();
+        ApiStub::stubResponses(['get_themes', 'get_theme_assets']);
+
+        // Run extraction
+        $this->helper->extractStoreMainTheme($this->shop->getId());
+
+        // No config defined, so the match should be empty
+        $this->assertEmpty($this->helper->templateJSONFiles());
+
+        // Define config, retest
+        $this->app['config']->set(
+            'shopify-app.theme_support.templates',
+            [
+                'shop', // Matches fixture data for `templates/shop.json`
+            ],
+        );
+        $this->assertNotEmpty($this->helper->templateJSONFiles());
+    }
+
+    public function testMainSections(): void
+    {
+        // Response stubbing
+        $this->setApiStub();
+        ApiStub::stubResponses(['get_themes', 'get_theme_assets', 'get_theme_asset_template_json']);
+
+        // Define config
+        $this->app['config']->set(
+            'shopify-app.theme_support.templates',
+            [
+                'shop', // Matches fixture data for `templates/shop.json`
+            ],
+        );
+
+        // Run extraction
+        $this->helper->extractStoreMainTheme($this->shop->getId());
+
+        // Get the main sections...
+        // `templates/shop.json`'s content in `get_theme_asset_template_json` fixture
+        // has a main of `product` which converts to `sections/product.liquid` which also
+        // exists in `get_theme_assets` fixture
+        $jsonFiles = $this->helper->templateJSONFiles();
+        $mainSections = $this->helper->mainSections($jsonFiles);
+
+        $this->assertNotEmpty($mainSections);
+    }
+
+    public function testSectionsWithAppBlock(): void
+    {
+        // Response stubbing
+        $this->setApiStub();
+        ApiStub::stubResponses([
+            'get_themes',
+            'get_theme_assets',
+            'get_theme_asset_template_json',
+            'get_theme_asset_product_section',
+        ]);
+
+        // Define config
+        $this->app['config']->set(
+            'shopify-app.theme_support.templates',
+            [
+                'shop', // Matches fixture data for `templates/shop.json`
+            ],
+        );
+
+        // Run extraction
+        $this->helper->extractStoreMainTheme($this->shop->getId());
+        $jsonFiles = $this->helper->templateJSONFiles();
+        $mainSections = $this->helper->mainSections($jsonFiles);
+        $sectionsWithApp = $this->helper->sectionsWithAppBlock($mainSections);
+
+        $this->assertNotEmpty($sectionsWithApp);
+    }
+}

--- a/tests/Services/ThemeHelperTest.php
+++ b/tests/Services/ThemeHelperTest.php
@@ -68,7 +68,7 @@ class ThemeHelperTest extends TestCase
             'shopify-app.theme_support.templates',
             [
                 'shop', // Matches fixture data for `templates/shop.json`
-            ],
+            ]
         );
         $this->assertNotEmpty($this->helper->templateJSONFiles());
     }

--- a/tests/Services/ThemeHelperTest.php
+++ b/tests/Services/ThemeHelperTest.php
@@ -84,7 +84,7 @@ class ThemeHelperTest extends TestCase
             'shopify-app.theme_support.templates',
             [
                 'shop', // Matches fixture data for `templates/shop.json`
-            ],
+            ]
         );
 
         // Run extraction
@@ -116,7 +116,7 @@ class ThemeHelperTest extends TestCase
             'shopify-app.theme_support.templates',
             [
                 'shop', // Matches fixture data for `templates/shop.json`
-            ],
+            ]
         );
 
         // Run extraction

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -27,7 +27,7 @@ class AuthControllerTest extends TestCase
         $response->assertViewHas('shopDomain', 'example.myshopify.com');
         $response->assertViewHas(
             'authUrl',
-            'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate'
+            'https://example.myshopify.com/admin/oauth/authorize?client_id='.Util::getShopifyConfig('api_key').'&scope=read_products%2Cwrite_products%2Cread_themes&redirect_uri=https%3A%2F%2Flocalhost%2Fauthenticate'
         );
     }
 

--- a/tests/fixtures/get_theme_asset_product_section.json
+++ b/tests/fixtures/get_theme_asset_product_section.json
@@ -1,0 +1,13 @@
+{
+    "asset": {
+      "key": "sections/product.liquid",
+      "public_url": null,
+      "value": "<div class=\"{% if section.settings.include_margins %}page-width{% endif %}\">\r\n  {%- for block in section.blocks -%}\r\n    {% render block %}\r\n  {%- endfor -%}\r\n<\/div>\r\n\r\n{% schema %}\r\n{\r\n  \"name\": \"t:sections.apps.name\",\r\n  \"tag\": \"section\",\r\n  \"class\": \"section\",\r\n  \"settings\": [\r\n    {\r\n      \"type\": \"checkbox\",\r\n      \"id\": \"include_margins\",\r\n      \"default\": true,\r\n      \"label\": \"t:sections.apps.settings.include_margins.label\"\r\n    }\r\n  ],\r\n  \"blocks\": [\r\n    {\r\n      \"type\": \"@app\"\r\n    }\r\n  ],\r\n  \"presets\": [\r\n    {\r\n      \"name\": \"t:sections.apps.presets.name\"\r\n    }\r\n  ]\r\n}\r\n{% endschema %}",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 1068,
+      "checksum": null,
+      "theme_id": 828155753
+    }
+  }

--- a/tests/fixtures/get_theme_asset_template_json.json
+++ b/tests/fixtures/get_theme_asset_template_json.json
@@ -1,0 +1,13 @@
+{
+  "asset": {
+    "key": "templates/shop.json",
+    "public_url": null,
+    "value": "{\"name\":\"Shop template\",\"wrapper\":\"div#div_id.div_class[attribute-one=value]\",\"sections\":{\"main\":{\"type\":\"product\"}},\"order\":[\"main\"]}",
+    "created_at": "2010-07-12T15:31:50-04:00",
+    "updated_at": "2010-07-12T15:31:50-04:00",
+    "content_type": "application/json",
+    "size": 1068,
+    "checksum": null,
+    "theme_id": 828155753
+  }
+}

--- a/tests/fixtures/get_theme_assets.json
+++ b/tests/fixtures/get_theme_assets.json
@@ -1,0 +1,284 @@
+{
+  "assets": [
+    {
+      "key": "layout/theme.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 3252,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/sidebar-devider.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/sidebar-devider.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1016,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-body-pink.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-body-pink.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1562,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-content.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-content.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 134,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "sections/header_section.liquid",
+      "public_url": null,
+      "created_at": "2017-04-28T10:30:00-04:00",
+      "updated_at": "2017-04-28T10:30:00-04:00",
+      "content_type": "application/x-liquid",
+      "size": 998,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/shop.css.liquid",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/shop.css.liquid?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 14675,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/shop.js",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/shop.js?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/javascript",
+      "size": 348,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-main.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-main.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 297,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "sections/content_section.liquid",
+      "public_url": null,
+      "created_at": "2016-02-11T14:31:50-05:00",
+      "updated_at": "2016-02-11T14:31:50-05:00",
+      "content_type": "application/x-liquid",
+      "size": 997,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/page.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 147,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-body-green.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-body-green.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1542,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/shop.css",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/shop.css?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "text/css",
+      "size": 14058,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "config/settings_schema.json",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/json",
+      "size": 4570,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "sections/product.liquid",
+      "public_url": null,
+      "created_at": "2016-02-14T16:31:41-05:00",
+      "updated_at": "2016-02-14T16:31:41-05:00",
+      "content_type": "application/x-liquid",
+      "size": 2440,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/blog.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 786,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/article.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 2486,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/product.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 2796,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "sections/footer_section.liquid",
+      "public_url": null,
+      "created_at": "2017-04-28T10:30:00-04:00",
+      "updated_at": "2017-04-28T10:30:00-04:00",
+      "content_type": "application/x-liquid",
+      "size": 999,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-footer.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-footer.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1434,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-sidebar.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-sidebar.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 124,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/bg-body-orange.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-body-orange.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1548,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/collection.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 946,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "assets/sidebar-menu.jpg",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/sidebar-menu.jpg?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/jpeg",
+      "size": 1609,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/cart.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 2047,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "config/settings_data.json",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/json",
+      "size": 4570,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+      "key": "templates/index.liquid",
+      "public_url": null,
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "application/x-liquid",
+      "size": 1068,
+      "checksum": null,
+      "theme_id": 828155753
+    },
+    {
+        "key": "templates/shop.json",
+        "public_url": null,
+        "created_at": "2010-07-12T15:31:50-04:00",
+        "updated_at": "2010-07-12T15:31:50-04:00",
+        "content_type": "application/json",
+        "size": 1068,
+        "checksum": null,
+        "theme_id": 828155753
+      },
+    {
+      "key": "assets/bg-body.gif",
+      "public_url": "https://cdn.shopify.com/s/files/1/0005/4838/0009/t/1/assets/bg-body.gif?v=1278963110",
+      "created_at": "2010-07-12T15:31:50-04:00",
+      "updated_at": "2010-07-12T15:31:50-04:00",
+      "content_type": "image/gif",
+      "size": 1571,
+      "checksum": null,
+      "theme_id": 828155753
+    }
+  ]
+}

--- a/tests/fixtures/get_themes.json
+++ b/tests/fixtures/get_themes.json
@@ -1,0 +1,37 @@
+{
+  "themes": [
+    {
+      "id": 828155753,
+      "name": "Comfort",
+      "created_at": "2022-07-02T01:51:59-04:00",
+      "updated_at": "2022-07-02T01:51:59-04:00",
+      "role": "main",
+      "theme_store_id": null,
+      "previewable": true,
+      "processing": false,
+      "admin_graphql_api_id": "gid://shopify/Theme/828155753"
+    },
+    {
+      "id": 976877075,
+      "name": "Preview of Parallax",
+      "created_at": "2022-07-02T01:51:59-04:00",
+      "updated_at": "2022-07-02T01:51:59-04:00",
+      "role": "demo",
+      "theme_store_id": 688,
+      "previewable": true,
+      "processing": false,
+      "admin_graphql_api_id": "gid://shopify/Theme/976877075"
+    },
+    {
+      "id": 752253240,
+      "name": "Sandbox",
+      "created_at": "2022-07-02T01:51:59-04:00",
+      "updated_at": "2022-07-02T01:51:59-04:00",
+      "role": "unpublished",
+      "theme_store_id": null,
+      "previewable": true,
+      "processing": false,
+      "admin_graphql_api_id": "gid://shopify/Theme/752253240"
+    }
+  ]
+}


### PR DESCRIPTION
As you know lately, Shopify does not allow applications that only use script tags.

To work with the Online Store 2.0 you need to use "Theme app extensions".
But in this case you should not install script tags.
If the store has not yet updated the theme and is using the Online Store 1.0, script tags must be installed.

These changes solve this problem