### PR TITLE
Remove the specific ResponseAccess type from activateCharge because o…

### DIFF
--- a/src/Contracts/ApiHelper.php
+++ b/src/Contracts/ApiHelper.php
@@ -123,7 +123,7 @@ interface ApiHelper
      *
      * @return ResponseAccess
      */
-    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess;
+    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef);
 
     /**
      * Create a charge.

--- a/src/Contracts/ApiHelper.php
+++ b/src/Contracts/ApiHelper.php
@@ -121,7 +121,7 @@ interface ApiHelper
      *
      * @throws RequestException
      *
-     * @return ResponseAccess
+     * @return mixed
      */
     public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef);
 

--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -234,7 +234,7 @@ class ApiHelper implements IApiHelper
      * {@inheritdoc}
      * TODO: Convert to GraphQL.
      */
-    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef): ResponseAccess
+    public function activateCharge(ChargeType $chargeType, ChargeReference $chargeRef)
     {
         // API path
         $typeString = $this->chargeApiPath($chargeType);


### PR DESCRIPTION
Remove the specific ResponseAccess type from activateCharge because of the recent update to Basic-Shopify-Api current() now returns "mixed" not ResponseAccess type.