### PR TITLE
Deprecation supports and fixes

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -333,8 +333,8 @@ class VerifyShopify
             DataSource::HEADER()->toNative() => $request->header('X-Shop-Signature'),
             // Headers: Referer
             DataSource::REFERER()->toNative() => function () use ($request): ?string {
-                $url = parse_url($request->header('referer'), PHP_URL_QUERY);
-                parse_str($url, $refererQueryParams);
+                $url = parse_url($request->header('referer', ''), PHP_URL_QUERY);
+                parse_str($url ?? '', $refererQueryParams);
                 if (! $refererQueryParams || ! isset($refererQueryParams['hmac'])) {
                     return null;
                 }

--- a/src/Objects/Values/ShopDomain.php
+++ b/src/Objects/Values/ShopDomain.php
@@ -53,7 +53,7 @@ final class ShopDomain implements ShopDomainValue
 
             // Headers: Referer
             DataSource::REFERER()->toNative() => function () use ($request): ?string {
-                $url = parse_url($request->header('referer'), PHP_URL_QUERY);
+                $url = parse_url($request->header('referer', ''), PHP_URL_QUERY);
                 if (! $url) {
                     return null;
                 }

--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -549,8 +549,8 @@ class ApiHelper implements IApiHelper
             },
             // Headers: Referer
             DataSource::REFERER()->toNative() => function (): ?string {
-                $url = parse_url(Request::server('HTTP_REFERER'), PHP_URL_QUERY);
-                parse_str($url, $refererQueryParams);
+                $url = parse_url(Request::server('HTTP_REFERER', ''), PHP_URL_QUERY);
+                parse_str($url ?? '', $refererQueryParams);
 
                 return Arr::get($refererQueryParams, 'shop');
             },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -96,6 +96,7 @@ abstract class TestCase extends OrchestraTestCase
             'prefix' => '',
         ]);
         $app['config']->set('auth.providers.users.model', UserStub::class);
+        $app['config']->set('logging.deprecations', 'errorlog');
     }
 
     protected function setupDatabase($app): void


### PR DESCRIPTION
* Fixes deprecation notices for PHP8
* Adds deprecation logging support to tests being run

Mainly, `parse_url` and `parse_str` calls have been updated. Warnings were present complaining about possible null values where a string is expected.

This PR adjusts to check for falsey/null and use a empty string as fallback.