### PR TITLE
Usage Charge "ID on Null" Fix

### DIFF
--- a/src/Http/Requests/StoreUsageCharge.php
+++ b/src/Http/Requests/StoreUsageCharge.php
@@ -73,6 +73,7 @@ class StoreUsageCharge extends FormRequest
             'price' => 'required|numeric',
             'description' => 'required|string',
             'redirect' => 'nullable|string',
+            'shop' => 'required|string',
         ];
     }
 }

--- a/src/Http/Requests/StoreUsageCharge.php
+++ b/src/Http/Requests/StoreUsageCharge.php
@@ -73,7 +73,6 @@ class StoreUsageCharge extends FormRequest
             'price' => 'required|numeric',
             'description' => 'required|string',
             'redirect' => 'nullable|string',
-            'shop' => 'required|string',
         ];
     }
 }

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -42,8 +42,7 @@ trait BillingController
         ShopQuery  $shopQuery,
         GetPlanUrl $getPlanUrl,
         ?int       $plan = null
-    ): ViewView
-    {
+    ): ViewView {
         // Get the shop
         $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
 
@@ -75,8 +74,7 @@ trait BillingController
         Request      $request,
         ShopQuery    $shopQuery,
         ActivatePlan $activatePlan
-    ): RedirectResponse
-    {
+    ): RedirectResponse {
         // Get the shop
         $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->query('shop')));
         if (!$request->has('charge_id')) {
@@ -88,7 +86,7 @@ trait BillingController
         $result = $activatePlan(
             $shop->getId(),
             PlanId::fromNative($plan),
-            ChargeReference::fromNative((int)$request->query('charge_id'))
+            ChargeReference::fromNative((int) $request->query('charge_id'))
         );
 
         // Go to homepage of app
@@ -107,17 +105,15 @@ trait BillingController
      * @param ActivateUsageCharge $activateUsageCharge The action for activating a usage charge.
      * @param ShopQuery $shopQuery The shop querier.
      *
-     * @return RedirectResponse
      * @throws MissingShopDomainException|ChargeNotRecurringException
      *
+     * @return RedirectResponse
      */
     public function usageCharge(
         StoreUsageCharge    $request,
         ActivateUsageCharge $activateUsageCharge,
         ShopQuery           $shopQuery
-    ): RedirectResponse
-    {
-
+    ): RedirectResponse {
         $shopDomain = NullableShopDomain::fromNative($request->get('shop'));
         // Get the shop from the shop param after it has been validated.
         if ($shopDomain->isNull()) {

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\View;
 use Osiset\ShopifyApp\Actions\ActivatePlan;
 use Osiset\ShopifyApp\Actions\ActivateUsageCharge;
 use Osiset\ShopifyApp\Actions\GetPlanUrl;
+use Osiset\ShopifyApp\Exceptions\ChargeNotRecurringException;
+use Osiset\ShopifyApp\Exceptions\MissingShopDomainException;
 use Osiset\ShopifyApp\Http\Requests\StoreUsageCharge;
 use Osiset\ShopifyApp\Objects\Transfers\UsageChargeDetails as UsageChargeDetailsTransfer;
 use Osiset\ShopifyApp\Objects\Values\ChargeReference;
@@ -100,12 +102,25 @@ trait BillingController
      *
      * @param StoreUsageCharge $request The verified request.
      * @param ActivateUsageCharge $activateUsageCharge The action for activating a usage charge.
+     * @param ShopQuery $shopQuery The shop querier.
+     *
+     * @throws MissingShopDomainException|ChargeNotRecurringException
      *
      * @return RedirectResponse
      */
-    public function usageCharge(StoreUsageCharge $request, ActivateUsageCharge $activateUsageCharge): RedirectResponse
-    {
+    public function usageCharge(
+        StoreUsageCharge    $request,
+        ActivateUsageCharge $activateUsageCharge,
+        ShopQuery           $shopQuery
+    ): RedirectResponse {
+        // Valid the request params.
         $validated = $request->validated();
+
+        // Get the shop from the shop param after it has been validated.
+        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($validated['shop']));
+        if (!$shop) {
+            throw new MissingShopDomainException('Shop parameter is missing from request');
+        }
 
         // Create the transfer object
         $ucd = new UsageChargeDetailsTransfer();
@@ -113,7 +128,7 @@ trait BillingController
         $ucd->description = $validated['description'];
 
         // Activate and save the usage charge
-        $activateUsageCharge($request->user()->getId(), $ucd);
+        $activateUsageCharge($shop->getId(), $ucd);
 
         // All done, return with success
         return isset($validated['redirect'])

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -115,10 +115,10 @@ trait BillingController
     ): RedirectResponse {
 
         // Get the shop from the shop param after it has been validated.
-        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
-        if (!$shop) {
+        if (!$request->get('shop')) {
             throw new MissingShopDomainException('Shop parameter is missing from request');
         }
+        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
 
         // Valid the request params.
         $validated = $request->validated();

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -16,6 +16,7 @@ use Osiset\ShopifyApp\Http\Requests\StoreUsageCharge;
 use Osiset\ShopifyApp\Objects\Transfers\UsageChargeDetails as UsageChargeDetailsTransfer;
 use Osiset\ShopifyApp\Objects\Values\ChargeReference;
 use Osiset\ShopifyApp\Objects\Values\NullablePlanId;
+use Osiset\ShopifyApp\Objects\Values\NullableShopDomain;
 use Osiset\ShopifyApp\Objects\Values\PlanId;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Storage\Queries\Shop as ShopQuery;
@@ -41,7 +42,8 @@ trait BillingController
         ShopQuery  $shopQuery,
         GetPlanUrl $getPlanUrl,
         ?int       $plan = null
-    ): ViewView {
+    ): ViewView
+    {
         // Get the shop
         $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
 
@@ -73,7 +75,8 @@ trait BillingController
         Request      $request,
         ShopQuery    $shopQuery,
         ActivatePlan $activatePlan
-    ): RedirectResponse {
+    ): RedirectResponse
+    {
         // Get the shop
         $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->query('shop')));
         if (!$request->has('charge_id')) {
@@ -85,7 +88,7 @@ trait BillingController
         $result = $activatePlan(
             $shop->getId(),
             PlanId::fromNative($plan),
-            ChargeReference::fromNative((int) $request->query('charge_id'))
+            ChargeReference::fromNative((int)$request->query('charge_id'))
         );
 
         // Go to homepage of app
@@ -104,20 +107,23 @@ trait BillingController
      * @param ActivateUsageCharge $activateUsageCharge The action for activating a usage charge.
      * @param ShopQuery $shopQuery The shop querier.
      *
+     * @return RedirectResponse
      * @throws MissingShopDomainException|ChargeNotRecurringException
      *
-     * @return RedirectResponse
      */
     public function usageCharge(
         StoreUsageCharge    $request,
         ActivateUsageCharge $activateUsageCharge,
         ShopQuery           $shopQuery
-    ): RedirectResponse {
+    ): RedirectResponse
+    {
+
+        $shopDomain = NullableShopDomain::fromNative($request->get('shop'));
         // Get the shop from the shop param after it has been validated.
-        if (!$request->get('shop')) {
+        if ($shopDomain->isNull()) {
             throw new MissingShopDomainException('Shop parameter is missing from request');
         }
-        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
+        $shop = $shopQuery->getByDomain($shopDomain);
 
         // Valid the request params.
         $validated = $request->validated();

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -113,14 +113,15 @@ trait BillingController
         ActivateUsageCharge $activateUsageCharge,
         ShopQuery           $shopQuery
     ): RedirectResponse {
-        // Valid the request params.
-        $validated = $request->validated();
 
         // Get the shop from the shop param after it has been validated.
-        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($validated['shop']));
+        $shop = $shopQuery->getByDomain(ShopDomain::fromNative($request->get('shop')));
         if (!$shop) {
             throw new MissingShopDomainException('Shop parameter is missing from request');
         }
+
+        // Valid the request params.
+        $validated = $request->validated();
 
         // Create the transfer object
         $ucd = new UsageChargeDetailsTransfer();

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -113,7 +113,6 @@ trait BillingController
         ActivateUsageCharge $activateUsageCharge,
         ShopQuery           $shopQuery
     ): RedirectResponse {
-
         // Get the shop from the shop param after it has been validated.
         if (!$request->get('shop')) {
             throw new MissingShopDomainException('Shop parameter is missing from request');

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Test\Traits;
 
 use Illuminate\Auth\AuthManager;
+use Osiset\ShopifyApp\Exceptions\MissingShopDomainException;
 use Osiset\ShopifyApp\Storage\Models\Charge;
 use Osiset\ShopifyApp\Storage\Models\Plan;
 use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
@@ -131,7 +132,7 @@ class BillingControllerTest extends TestCase
         $response->assertSessionHas('success');
     }
 
-    public function testReturnToSettingScreenNoPlan()
+    public function testReturnToSettingScreenNoPlan(): void
     {
         // Set up a shop
         $shop = factory($this->model)->create([
@@ -150,7 +151,7 @@ class BillingControllerTest extends TestCase
         $response->assertRedirect('https://example-app.com?shop='.$shop->name);
     }
 
-    public function testUsageChargeSuccessWithShopParam()
+    public function testUsageChargeSuccessWithShopParam(): void
     {
         // Stub the responses
         ApiStub::stubResponses([
@@ -184,5 +185,48 @@ class BillingControllerTest extends TestCase
         $response->assertRedirect($data['redirect']);
         $response->assertSessionHas('success');
         $this->assertDatabaseHas('charges', ['description' => 'One email']);
+    }
+
+    public function testUsageChargeFailWithoutShopParam(): void
+    {
+
+        $this->withoutExceptionHandling();
+        $this->expectException(MissingShopDomainException::class);
+
+        // Stub the responses
+        ApiStub::stubResponses([
+            'post_recurring_application_charges_usage_charges_alt',
+        ]);
+
+        // Create the shop
+        $plan = factory(Util::getShopifyConfig('models.plan', Plan::class))
+            ->states('type_recurring')->create();
+        $shop = factory($this->model)->create([
+            'plan_id' => $plan->getId()->toNative(),
+        ]);
+        factory(Util::getShopifyConfig('models.charge', Charge::class))
+            ->states('type_recurring')->create([
+                'plan_id' => $plan->getId()->toNative(),
+                'user_id' => $shop->getId()->toNative(),
+            ]);
+
+        // Login the shop
+        $this->auth->login($shop);
+
+        // Set up the data for the usage charge and the signature for it
+        $secret = $this->app['config']->get('shopify-app.api_secret');
+        $data = [
+            'description' => 'One email',
+            'price' => 1.00,
+            'redirect' => 'https://localhost/usage-success', ];
+        $signature = Util::createHmac(['data' => $data, 'buildQuery' => true], $secret);
+
+        // Run the call
+        $response = $this->call(
+            'post',
+            '/billing/usage-charge',
+            array_merge($data, ['signature' => $signature->toNative()])
+        );
+        $this->assertDatabaseMissing('charges', ['description' => 'One email']);
     }
 }

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -112,7 +112,7 @@ class BillingControllerTest extends TestCase
         $response = $this->call(
             'post',
             '/billing/usage-charge',
-            array_merge($data, ['signature' => $signature->toNative()])
+            array_merge($data, ['signature' => $signature->toNative(), 'shop' => $shop->name])
         );
         $response->assertRedirect($data['redirect']);
         $response->assertSessionHas('success');
@@ -125,7 +125,7 @@ class BillingControllerTest extends TestCase
         $response = $this->call(
             'post',
             '/billing/usage-charge',
-            array_merge($data, ['signature' => $signature->toNative()])
+            array_merge($data, ['signature' => $signature->toNative(), 'shop' => $shop->name])
         );
         $response->assertRedirect('http://localhost');
         $response->assertSessionHas('success');

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -189,7 +189,6 @@ class BillingControllerTest extends TestCase
 
     public function testUsageChargeFailWithoutShopParam(): void
     {
-
         $this->withoutExceptionHandling();
         $this->expectException(MissingShopDomainException::class);
 
@@ -218,7 +217,7 @@ class BillingControllerTest extends TestCase
         $data = [
             'description' => 'One email',
             'price' => 1.00,
-            'redirect' => 'https://localhost/usage-success', ];
+            'redirect' => 'https://localhost/usage-success',];
         $signature = Util::createHmac(['data' => $data, 'buildQuery' => true], $secret);
 
         // Run the call


### PR DESCRIPTION
Currently, the usage Charge method is trying to get the user from the session but it is not available.

This updates the route to expect the shop domain to be passed in like the other functions.