### PR TITLE
Adding event to notify App Installation on the store

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "funeralzone/valueobjects": "^0.5",
         "jenssegers/agent": "^2.6",
-        "laravel/framework": "^7.0 || ^8.0 || ^9.0",
+        "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "osiset/basic-shopify-api": "^9.0 || <=10.0.5"
     },
     "require-dev": {

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Actions;
 use Exception;
 use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Messaging\Events\AppInstalled;
 use Osiset\ShopifyApp\Objects\Enums\AuthMode;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
@@ -87,6 +88,9 @@ class InstallShop
             // Get the data and set the access token
             $data = $apiHelper->getAccessData($code);
             $this->shopCommand->setAccessToken($shop->getId(), AccessToken::fromNative($data['access_token']));
+
+            // Fire the AppInstalled event
+            AppInstalled::dispatch($shop);
 
             return [
                 'completed' => true,

--- a/src/Messaging/Events/AppInstalled.php
+++ b/src/Messaging/Events/AppInstalled.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Osiset\ShopifyApp\Messaging\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+
+class AppInstalled
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Shop's instance.
+     *
+     * @var string
+     */
+    protected $shop;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param IShopModel $shop The shop.
+     *
+     * @return void
+     */
+    public function __construct(IShopModel $shop)
+    {
+        $this->shop = $shop;
+    }
+
+    public function getShop()
+    {
+        return $this->shop;
+    }
+}


### PR DESCRIPTION
The `AppInstalled` event will be triggered after the installation of App on the store. This can be used to run jobs after successful installation. For example, fetching data from the store that is needed by the application.

Here is an example of how to set up a Listener and subscribe to it on the project's EventServiceProvider.

```php

<?php

namespace App\Listeners;

use Osiset\ShopifyApp\Messaging\Events\AppInstalled;

class AppInstalledEventListener
{
    /**
     * Handle AppInstalled Event.
     *
     * @param  Osiset\ShopifyApp\Messaging\Events\AppInstalled $event
     * @return void
     */
    public function handle(AppInstalled $event)
    {
            $shop = $event->getShop();
            // Get Shop Details
            // Get Products
            // Get Collections
            // etc...
    }
}
```

Once your listener has been defined, you may register it within your application's `EventServiceProvider`:

```php
<?php

namespace App\Providers;

use App\Listeners\AppInstalledEventListener;
use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
use Osiset\ShopifyApp\Messaging\Events\AppInstalled;

class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        AppInstalled::class => [
            AppInstalledEventListener::class,
        ],
    ];
}
```

@Kyon147, I am resending this PR again as the last PR (#1058) had additional code that was already merged in to the repo.