### PR TITLE
Removed `!!` from the full_page_redirect breaking authenticate route

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -23,9 +23,9 @@
                     var createApp = AppBridge.default;
                     var Redirect = AppBridge.actions.Redirect;
                     var app = createApp({
-                        apiKey: "{{!! $apiKey !!}}",
-                        shopOrigin: "{{!! $shopOrigin !!}}",
-                        host: "{{!! $host !!}}",
+                        apiKey: "{{ $apiKey }}",
+                        shopOrigin: "{{ $shopOrigin }}",
+                        host: "{{ $host }}",
                     });
 
                     var redirect = Redirect.create(app);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,6 +43,11 @@ abstract class TestCase extends OrchestraTestCase
      */
     protected $now;
 
+    /*
+     * Fixes the issue with test bench core.
+     * */
+    public static $latestResponse = null;
+
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
Currently the authenticated route can break usually on a proper visit to /authenticate because of the `{{!! !!}}` formatting in the blade template for the api key, shop origin and host. 