### PR TITLE
Added parameter to billing process

### DIFF
--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -92,6 +92,7 @@ trait BillingController
         // Go to homepage of app
         return Redirect::route(Util::getShopifyConfig('route_names.home'), [
             'shop' => $shop->getDomain()->toNative(),
+            'billing' => $result ? 'success' : 'failure'
         ])->with(
             $result ? 'success' : 'failure',
             'billing'


### PR DESCRIPTION
When a merchant accepts/declines billing this will add a parameter 'billing -> success' to the home page route. This way developers can detect when billing is accepted/declined.