### PR TITLE
AppBridge : Add the host param to the billing redirect url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             laravel: '9.0'
         include:
           - php: '8.0'
-            laravel: '9.0'
+            laravel: '9.39.0'
             analysis: true
             coverage: 'xdebug'
             normalize: true

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -80,7 +80,7 @@ trait BillingController
         if (!$request->has('charge_id')) {
             return Redirect::route(Util::getShopifyConfig('route_names.home'), [
                 'shop' => $shop->getDomain()->toNative(),
-                'host' => base64_encode($shop->getDomain()->toNative().'/admin')
+                'host' => base64_encode($shop->getDomain()->toNative().'/admin'),
             ]);
         }
         // Activate the plan and save
@@ -93,7 +93,7 @@ trait BillingController
         // Go to homepage of app
         return Redirect::route(Util::getShopifyConfig('route_names.home'), [
             'shop' => $shop->getDomain()->toNative(),
-            'host' => base64_encode($shop->getDomain()->toNative().'/admin')
+            'host' => base64_encode($shop->getDomain()->toNative().'/admin'),
         ])->with(
             $result ? 'success' : 'failure',
             'billing'

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -94,6 +94,7 @@ trait BillingController
         return Redirect::route(Util::getShopifyConfig('route_names.home'), [
             'shop' => $shop->getDomain()->toNative(),
             'host' => base64_encode($shop->getDomain()->toNative().'/admin'),
+            'billing' => $result ? 'success' : 'failure',
         ])->with(
             $result ? 'success' : 'failure',
             'billing'

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -80,6 +80,7 @@ trait BillingController
         if (!$request->has('charge_id')) {
             return Redirect::route(Util::getShopifyConfig('route_names.home'), [
                 'shop' => $shop->getDomain()->toNative(),
+                'host' => base64_encode($shop->getDomain()->toNative().'/admin')
             ]);
         }
         // Activate the plan and save
@@ -92,6 +93,7 @@ trait BillingController
         // Go to homepage of app
         return Redirect::route(Util::getShopifyConfig('route_names.home'), [
             'shop' => $shop->getDomain()->toNative(),
+            'host' => base64_encode($shop->getDomain()->toNative().'/admin')
         ])->with(
             $result ? 'success' : 'failure',
             'billing'

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -152,7 +152,8 @@ class BillingControllerTest extends TestCase
             ['shop' => $shop->name]
         );
         //Confirm we get sent back to the homepage of the app
-        $response->assertRedirect('https://example-app.com?shop='.$shop->name);
+        $hostValue = urlencode(base64_encode($shop->getDomain()->toNative().'/admin'));
+        $response->assertRedirect('https://example-app.com?shop='.$shop->name.'&host='.$hostValue);
     }
 
     public function testUsageChargeSuccessWithShopParam(): void

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -78,8 +78,11 @@ class BillingControllerTest extends TestCase
         // Refresh the model
         $shop->refresh();
 
+        $hostValue = urlencode(base64_encode($shop->getDomain()->toNative().'/admin'));
         // Assert we've redirected and shop has been updated
         $response->assertRedirect();
+        $response->assertRedirectContains('&host='.$hostValue);
+        $response->assertRedirectContains('&billing=success');
         $this->assertNotNull($shop->plan);
     }
 

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Test\Traits;
 
 use Illuminate\Auth\AuthManager;
+use Illuminate\Support\Str;
 use Osiset\ShopifyApp\Exceptions\MissingShopDomainException;
 use Osiset\ShopifyApp\Storage\Models\Charge;
 use Osiset\ShopifyApp\Storage\Models\Plan;
@@ -81,8 +82,8 @@ class BillingControllerTest extends TestCase
         $hostValue = urlencode(base64_encode($shop->getDomain()->toNative().'/admin'));
         // Assert we've redirected and shop has been updated
         $response->assertRedirect();
-        $response->assertRedirectContains('&host='.$hostValue);
-        $response->assertRedirectContains('&billing=success');
+        $this->assertTrue(Str::contains($response->headers->get('Location'), '&host='.$hostValue));
+        $this->assertTrue(Str::contains($response->headers->get('Location'), '&billing=success'));
         $this->assertNotNull($shop->plan);
     }
 


### PR DESCRIPTION
Currently when trying to use AppBridge within an SPA, if we leave the SPA context like when billing happens we need to not only pass the shop param but also the new host param that shopify uses to load AppBridge.  