### PR TITLE
Updates to token_handler.blade.php to support Livewire 2.x

### DIFF
--- a/src/resources/views/partials/token_handler.blade.php
+++ b/src/resources/views/partials/token_handler.blade.php
@@ -31,6 +31,15 @@
                 window.jQuery.ajaxSettings.headers = { 'Authorization': bearer };
             }
         }
+		
+		if (window.Livewire) {
+            // livewire
+            window.livewire.addHeaders({
+                'Authorization': bearer,
+                'content-type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            });
+        }
 
         if (window.axios) {
             // Axios


### PR DESCRIPTION
Currently there is no support for Livewire 2.x. This PR provides support for Livewire 2.x by incorporating the required headers into `token_handler.blade.php`.

This closes #1245 